### PR TITLE
Update companion app repo reference to airspin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 BabelPod is an audio streaming system with two repositories:
 
 - **This repo** (`benlachman/babelpod`) — Node.js server + web UI. The server (`index.js`) captures audio from a selected input and streams it to multiple outputs. The web UI (`index.html`) is served by Express. Both are plain JavaScript, no build step.
-- **iOS/macOS app** (`nicemohawk/analog2air`) at `/Users/ben/Development/BabelUI` — SwiftUI client that connects to the same server. Separate repo, separate release cycle, but must maintain API parity.
+- **iOS/macOS app** (`nicemohawk/airspin`) at `/Users/ben/Development/BabelUI` — SwiftUI client that connects to the same server. Separate repo, separate release cycle, but must maintain API parity.
 
 The server runs on a **Raspberry Pi Zero 2 W** (ARM64, 512MB RAM, Debian/Trixie). Audio capture and playback use ALSA tools (`arecord`, `aplay`) via spawned child processes. AirPlay streaming uses `node_airtunes2`. Bluetooth input uses `bluetoothctl` via a Node wrapper. Device discovery uses `dnssd2` (mDNS) and `mdns-js`.
 
@@ -77,7 +77,7 @@ Documented in `API.md`. Key design points:
 
 ## Companion iOS/macOS App
 
-The SwiftUI client lives at `/Users/ben/Development/BabelUI` (separate repo: `nicemohawk/analog2air`). It consumes the same v1 API. Key files:
+The SwiftUI client lives at `/Users/ben/Development/BabelUI` (separate repo: `nicemohawk/airspin`). It consumes the same v1 API. Key files:
 - `BabelPodClientView.swift` — ViewModel with Socket.IO client, Combine publishers for state sync
 - `ContentView.swift` — NavigationStack with connection Menu
 - `ServiceDiscoveryManager.swift` — Bonjour discovery via NWBrowser


### PR DESCRIPTION
## Summary
- Update CLAUDE.md references from `nicemohawk/analog2air` to `nicemohawk/airspin` after repo rename

## Test plan
- [ ] Links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)