### PR TITLE
Add autoconnect, process management, and -t raw fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/config.gypi
 coverage
 .nyc_output
 *.log
+babelpod.config.json

--- a/API.md
+++ b/API.md
@@ -133,6 +133,90 @@ Claim session ownership. No payload required.
 {}
 ```
 
+### `setConfig`
+
+Update instance configuration. Partial updates allowed — only fields present are changed. Requires session ownership.
+
+```json
+{
+  "displayName": "Living Room Pi",
+  "defaultInputId": "plughw:0,0",
+  "defaultOutputIds": ["air:Kitchen", "air:Living Room"],
+  "defaultVolume": 50,
+  "autoplayEnabled": true,
+  "autoplayThreshold": 0.002
+}
+```
+
+### `setAutoplay`
+
+Toggle the autoplay state machine. `"playing"` arms autoplay (enters idle/listening). `"paused"` is a master kill switch — stops all outputs immediately. Requires session ownership.
+
+```json
+{ "state": "playing" }
+```
+
+## Instance Configuration
+
+BabelPod stores instance configuration in `babelpod.config.json` alongside the server. Configuration persists across restarts and is editable from any client via the `setConfig` event.
+
+### Server to Client
+
+**`config`** — Sent when configuration changes. Also included in the `state` event on connection.
+
+```json
+{
+  "displayName": "PattyPi",
+  "defaultInputId": "plughw:0,0",
+  "defaultOutputIds": ["air:Kitchen"],
+  "defaultVolume": 50,
+  "autoplayEnabled": true,
+  "autoplayThreshold": 0.002
+}
+```
+
+## Autoplay
+
+BabelPod can automatically detect audio on the input and route it to configured default speakers.
+
+### Server to Client
+
+**`autoplay`** — Sent when the autoplay state changes.
+
+```json
+{ "state": "idle" }
+```
+
+Valid states: `"paused"`, `"idle"`, `"detecting"`, `"playing"`, `"silence"`
+
+**`rmsLevel`** — Sent at ~4Hz with the current input audio level (0.0-1.0 range).
+
+```json
+{ "level": 0.042 }
+```
+
+### State Machine
+
+- **paused** — Master kill switch. All outputs stopped. Autoplay won't trigger.
+- **idle** — Armed and listening. Monitoring input RMS level. Outputs disconnected.
+- **detecting** — Signal above threshold detected, sustaining for 250ms to filter transient bumps.
+- **playing** — Audio routing active. Default outputs connected.
+- **silence** — Silence detected while playing. Outputs disconnect after 5 minutes of sustained silence.
+
+The `"playing"` client command enters `idle` (arms autoplay). The `"paused"` command stops everything immediately. On server restart, state is determined by `config.autoplayEnabled`.
+
+### Extended `state` Event
+
+The `state` event now includes two additional fields:
+
+```json
+{
+  ...existing fields...,
+  "config": { ... },
+  "autoplayState": "idle"
+}
+```
+
 ## Session Ownership
 
 Only one client controls BabelPod at a time. The session model works as follows:

--- a/API.md
+++ b/API.md
@@ -143,17 +143,17 @@ Update instance configuration. Partial updates allowed — only fields present a
   "defaultInputId": "plughw:0,0",
   "defaultOutputIds": ["air:Kitchen", "air:Living Room"],
   "defaultVolume": 50,
-  "autoplayEnabled": true,
-  "autoplayThreshold": 0.002
+  "autoconnectEnabled": true,
+  "autoconnectThreshold": 0.01
 }
 ```
 
-### `setAutoplay`
+### `setAutoconnect`
 
-Toggle the autoplay state machine. `"playing"` arms autoplay (enters idle/listening). `"paused"` is a master kill switch — stops all outputs immediately. Requires session ownership.
+Toggle the autoconnect state machine. `"listening"` arms autoconnect (enters idle/listening). `"paused"` is a master kill switch — stops all outputs immediately. Requires session ownership.
 
 ```json
-{ "state": "playing" }
+{ "state": "listening" }
 ```
 
 ## Instance Configuration
@@ -170,24 +170,24 @@ BabelPod stores instance configuration in `babelpod.config.json` alongside the s
   "defaultInputId": "plughw:0,0",
   "defaultOutputIds": ["air:Kitchen"],
   "defaultVolume": 50,
-  "autoplayEnabled": true,
-  "autoplayThreshold": 0.002
+  "autoconnectEnabled": true,
+  "autoconnectThreshold": 0.01
 }
 ```
 
-## Autoplay
+## Autoconnect
 
-BabelPod can automatically detect audio on the input and route it to configured default speakers.
+BabelPod can automatically detect audio on the input and route it to configured default speakers. Uses RMS level monitoring with an exponential moving average to distinguish sustained music from transient surface noise.
 
 ### Server to Client
 
-**`autoplay`** — Sent when the autoplay state changes.
+**`autoconnect`** — Sent when the autoconnect state changes.
 
 ```json
 { "state": "idle" }
 ```
 
-Valid states: `"paused"`, `"idle"`, `"detecting"`, `"playing"`, `"silence"`
+Valid states: `"paused"`, `"idle"`, `"detecting"`, `"connected"`, `"silence"`
 
 **`rmsLevel`** — Sent at ~4Hz with the current input audio level (0.0-1.0 range).
 
@@ -197,23 +197,28 @@ Valid states: `"paused"`, `"idle"`, `"detecting"`, `"playing"`, `"silence"`
 
 ### State Machine
 
-- **paused** — Master kill switch. All outputs stopped. Autoplay won't trigger.
+- **paused** — Master kill switch. All outputs stopped. Autoconnect won't trigger.
 - **idle** — Armed and listening. Monitoring input RMS level. Outputs disconnected.
-- **detecting** — Signal above threshold detected, sustaining for 250ms to filter transient bumps.
-- **playing** — Audio routing active. Default outputs connected.
-- **silence** — Silence detected while playing. Outputs disconnect after 5 minutes of sustained silence.
+- **detecting** — Signal above threshold detected, sustaining for 250ms to filter transient bumps (e.g., table bumps). Uses raw RMS.
+- **connected** — Audio routing active. Default outputs connected. Uses smoothed RMS with hysteresis (threshold/4) to avoid flip-flopping during quiet passages.
+- **silence** — Silence detected while connected. Outputs disconnect after 5 minutes of sustained silence. Uses smoothed RMS.
 
-The `"playing"` client command enters `idle` (arms autoplay). The `"paused"` command stops everything immediately. On server restart, state is determined by `config.autoplayEnabled`.
+The `"listening"` client command enters `idle` (arms autoconnect). The `"paused"` command stops everything immediately. On server restart, state is determined by `config.autoconnectEnabled`.
+
+### Threshold Configuration
+
+- **Phono mode** (with preamp): threshold `0.01` — music at 0.03-0.08 smoothed, surface noise at 0.001-0.002 smoothed
+- **Line mode** (no preamp): threshold `0.0005` — much quieter signal
 
 ### Extended `state` Event
 
-The `state` event now includes two additional fields:
+The `state` event includes config and autoconnect state:
 
 ```json
 {
   ...existing fields...,
   "config": { ... },
-  "autoplayState": "idle"
+  "autoconnectState": "idle"
 }
 ```
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -28,6 +28,15 @@ The Burr-Brown/TI USB Audio CODEC has no ALSA capture volume control — gain is
 - Add an input gain slider to the UI (web + SwiftUI)
 - Consider adding a signal level meter to the UI so users can visually confirm input levels
 
+## iOS App: Push Notification to Turn Off Record Player
+
+When autoconnect transitions from silence to idle (speakers released after 5 minutes of silence), send a push notification from the iOS app reminding the user to turn off the record player. The record is still spinning in the runout groove — the user may have walked away.
+
+Should be gated by a toggle in settings (off by default). Requires the server to emit the silence→idle transition event.
+
+- **iOS:** Register for push notifications, display alert when backgrounded
+- **Web:** Use the Web Notifications API (`Notification.requestPermission()` + `new Notification(...)`) — works even when the tab is in the background, no server-side push infrastructure needed
+
 ## iOS App: Unused ServicePickerView
 
 `BabelUI/ServicePickerView.swift` defines a service picker component that is not integrated into the app. Either integrate it into the connection flow or remove it to reduce dead code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,11 @@ The SwiftUI client lives at `/Users/ben/Development/BabelUI` (separate repo: `ni
 ## Workflow
 
 - **Always use branches and PRs.** Do not commit directly to master/main. Squash merge and delete the branch after merging.
+- **Prefer new commits over amending.** Amending pushed commits should be extremely rare. Only amend unpushed commits when the change is a correction to that commit, not new work. When in doubt, create a new commit.
 - **Lint and build after every change.** Run `node -c index.js` after any server edit. Build the iOS app after any Swift edit.
 - **Ask before making breaking API changes.** The API has multiple clients (web UI, iOS app). Discuss versioning strategy before changing event names, payload shapes, or removing events.
 - **iOS and web UI must have feature parity.** Any feature added to one client must be added to the other.
+- **Always include PR URLs.** When referencing pull requests, include the full URL so they're clickable.
 
 ## Code Style
 

--- a/babelpod.service
+++ b/babelpod.service
@@ -26,9 +26,11 @@ Environment=LOG_LEVEL=debug
 # Start the Node 20 binary directly
 ExecStart=/usr/bin/node /home/pi/babelpod/index.js
 
-# Restart strategy: keep service alive
+# Restart strategy: keep service alive, rate-limited to prevent infinite loops
 Restart=always
 RestartSec=5
+StartLimitBurst=5
+StartLimitIntervalSec=300
 
 # Audio performance tuning
 Nice=-5

--- a/babelpod.service
+++ b/babelpod.service
@@ -19,6 +19,9 @@ WorkingDirectory=/home/pi/babelpod
 Environment=NODE_ENV=production
 # Some audio libs rely on XDG_RUNTIME_DIR to talk to BlueZ cleanly
 Environment=XDG_RUNTIME_DIR=/run/user/1000
+# LOG_LEVEL: debug | info | warn | error (default: info)
+# Use debug while tuning autoconnect thresholds; dial back to info for steady state
+Environment=LOG_LEVEL=debug
 
 # Start the Node 20 binary directly
 ExecStart=/usr/bin/node /home/pi/babelpod/index.js

--- a/babelpod.service
+++ b/babelpod.service
@@ -3,6 +3,8 @@
 Description=Babelpod audio streaming service
 Wants=network-online.target avahi-daemon.service bluetooth.target
 After=network-online.target avahi-daemon.service bluetooth.target sound.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
 
 [Service]
 Type=simple
@@ -29,8 +31,6 @@ ExecStart=/usr/bin/node --max-old-space-size=128 /home/pi/babelpod/index.js
 # Restart strategy: keep service alive, rate-limited to prevent infinite loops
 Restart=always
 RestartSec=5
-StartLimitBurst=5
-StartLimitIntervalSec=300
 
 # Audio performance tuning
 Nice=-5

--- a/babelpod.service
+++ b/babelpod.service
@@ -24,7 +24,7 @@ Environment=XDG_RUNTIME_DIR=/run/user/1000
 Environment=LOG_LEVEL=debug
 
 # Start the Node 20 binary directly
-ExecStart=/usr/bin/node /home/pi/babelpod/index.js
+ExecStart=/usr/bin/node --max-old-space-size=128 /home/pi/babelpod/index.js
 
 # Restart strategy: keep service alive, rate-limited to prevent infinite loops
 Restart=always

--- a/index.html
+++ b/index.html
@@ -704,7 +704,7 @@
       function updateSettingsForm() {
         document.getElementById("settingsDisplayName").value = currentConfig.displayName || "";
         document.getElementById("settingsAutoconnectEnabled").checked = currentConfig.autoconnectEnabled || false;
-        document.getElementById("settingsInputMode").value = (currentConfig.autoconnectThreshold || 0.005) < 0.002 ? "line" : "phono";
+        document.getElementById("settingsInputMode").value = (currentConfig.autoconnectThreshold || 0.01) < 0.002 ? "line" : "phono";
         document.getElementById("settingsDefaultVolume").value = currentConfig.defaultVolume || 50;
         updateSettingsVolumeProgress();
 
@@ -754,7 +754,7 @@
         const inputMode = document.getElementById("settingsInputMode").value;
         // Phono mode: signal amplified by preamp (~0.03+ music), higher threshold
         // Line mode: signal not amplified (~0.002 music), lower threshold
-        const autoconnectThreshold = inputMode === "line" ? 0.0005 : 0.005;
+        const autoconnectThreshold = inputMode === "line" ? 0.0005 : 0.01;
 
         socket.emit("setConfig", {
           displayName: document.getElementById("settingsDisplayName").value,

--- a/index.html
+++ b/index.html
@@ -175,11 +175,103 @@
       #sessionOverlay button:hover {
         background: #666;
       }
+
+      /* Autoplay controls */
+      .autoplay-section {
+        text-align: center;
+        padding: 1rem 0;
+        border-bottom: 1px solid #333;
+        margin-bottom: 0.5rem;
+      }
+      .autoplay-button {
+        width: 64px;
+        height: 64px;
+        border-radius: 50%;
+        border: none;
+        cursor: pointer;
+        font-size: 1.5rem;
+        color: white;
+        transition: background 0.2s;
+      }
+      .autoplay-button.active {
+        background: #2e7d32;
+      }
+      .autoplay-button.paused {
+        background: #555;
+      }
+      .autoplay-button:hover {
+        opacity: 0.85;
+      }
+      .autoplay-status {
+        font-size: 0.85rem;
+        color: #999;
+        margin-top: 0.5rem;
+      }
+      .rms-bar-container {
+        height: 4px;
+        background: #333;
+        border-radius: 2px;
+        margin-top: 0.75rem;
+        overflow: hidden;
+      }
+      .rms-bar {
+        height: 100%;
+        background: linear-gradient(to right, #4CAF50, #8BC34A);
+        width: 0%;
+        transition: width 0.1s linear;
+        border-radius: 2px;
+      }
+
+      /* Settings section */
+      details.settings {
+        margin-top: 1rem;
+      }
+      details.settings summary {
+        cursor: pointer;
+        font-weight: 500;
+        color: #aaa;
+        padding: 0.5rem 0;
+      }
+      details.settings .settings-content {
+        padding: 0.5rem 0;
+      }
+      details.settings input[type="text"],
+      details.settings select {
+        width: 100%;
+        padding: 0.5rem;
+        background: #2a2a2a;
+        border: 1px solid #444;
+        border-radius: 4px;
+        color: #ddd;
+        font-size: 0.9rem;
+        box-sizing: border-box;
+      }
+      details.settings .save-button {
+        margin-top: 1rem;
+        padding: 0.5rem 1.5rem;
+        background: #2e7d32;
+        border: none;
+        border-radius: 4px;
+        color: white;
+        cursor: pointer;
+        font-size: 0.9rem;
+      }
+      details.settings .save-button:hover {
+        background: #388e3c;
+      }
     </style>
   </head>
   <body>
-    <header>BabelPod</header>
+    <header id="serverName">BabelPod</header>
     <div class="container">
+      <div class="autoplay-section">
+        <button id="autoplayButton" class="autoplay-button paused" onclick="toggleAutoplay()">&#9654;</button>
+        <div class="autoplay-status" id="autoplayStatusText">Paused</div>
+        <div class="rms-bar-container">
+          <div class="rms-bar" id="rmsBar"></div>
+        </div>
+      </div>
+
       <label>Input Device</label>
       <div class="radio-list" id="inputsList"></div>
 
@@ -197,6 +289,31 @@
         <p id="statusMessage" style="color: #4CAF50; margin-top: 1rem;"></p>
         <p id="errorMessage" style="color: #f44336; margin-top: 0.5rem;"></p>
       </div>
+
+      <details class="settings">
+        <summary>Settings</summary>
+        <div class="settings-content">
+          <label>Display Name</label>
+          <input type="text" id="settingsDisplayName" />
+
+          <label>Default Input</label>
+          <select id="settingsDefaultInput"></select>
+
+          <label>Default Outputs</label>
+          <div class="checkbox-list" id="settingsDefaultOutputs"></div>
+
+          <label>Default Volume</label>
+          <input type="range" min="0" max="100" value="50" id="settingsDefaultVolume" />
+          <span id="settingsDefaultVolumeText">50</span>
+
+          <label style="display: flex; align-items: center; gap: 0.5rem; margin-top: 0.75rem;">
+            <input type="checkbox" id="settingsAutoplayEnabled" style="transform: scale(1.2);" />
+            Autoplay on boot
+          </label>
+
+          <button class="save-button" onclick="saveSettings()">Save Settings</button>
+        </div>
+      </details>
     </div>
 
     <div id="sessionOverlay">
@@ -230,6 +347,9 @@
       let lastEmittedVolume = null;
       let lastEmittedOutputs = null;
       let lastEmittedInput = null;
+      let currentConfig = {};
+      let currentAutoplayState = "paused";
+      let availableOutputsList = [];
 
       const inputsList = document.getElementById("inputsList");
       const volumeRange = document.getElementById("outputVolume");
@@ -336,6 +456,7 @@
       // Full state bundle on connection
       socket.on("state", (s) => {
         availableInputsList = s.inputs;
+        availableOutputsList = s.outputs;
         currentInput = s.selectedInput;
         currentOutputs = s.selectedOutputs;
         currentVolume = s.volume;
@@ -350,6 +471,16 @@
         curInputText.textContent = s.selectedInput;
         updateSliderProgress();
         updateOverlay();
+
+        if (s.config) {
+          currentConfig = s.config;
+          updateSettingsForm();
+          updateServerName();
+        }
+        if (s.autoplayState) {
+          currentAutoplayState = s.autoplayState;
+          updateAutoplayButton();
+        }
       });
 
       // Incremental updates
@@ -358,6 +489,7 @@
         renderInputsList();
       });
       socket.on("outputs", (d) => {
+        availableOutputsList = d.outputs;
         renderOutputsList(d.outputs);
         renderActiveOutputs();
       });
@@ -415,6 +547,105 @@
       socket.on("connect_error", (error) => {
         showError("Connection error: " + error.message);
       });
+
+      // Config and autoplay events
+      socket.on("config", (c) => {
+        currentConfig = c;
+        updateSettingsForm();
+        updateServerName();
+      });
+      socket.on("autoplay", (d) => {
+        currentAutoplayState = d.state;
+        updateAutoplayButton();
+      });
+      socket.on("rmsLevel", (d) => {
+        const rmsBar = document.getElementById("rmsBar");
+        // Scale RMS for visibility (0-0.3 range mapped to 0-100%)
+        const widthPercent = Math.min(100, (d.level / 0.3) * 100);
+        rmsBar.style.width = widthPercent + "%";
+      });
+
+      // Autoplay controls
+      function toggleAutoplay() {
+        const newState = currentAutoplayState === "paused" ? "playing" : "paused";
+        socket.emit("setAutoplay", { state: newState });
+      }
+
+      function updateAutoplayButton() {
+        const button = document.getElementById("autoplayButton");
+        const statusText = document.getElementById("autoplayStatusText");
+        const isPaused = currentAutoplayState === "paused";
+
+        button.className = "autoplay-button " + (isPaused ? "paused" : "active");
+        button.innerHTML = isPaused ? "&#9654;" : "&#10074;&#10074;";
+
+        const labels = {
+          paused: "Paused",
+          idle: "Listening...",
+          detecting: "Sound detected...",
+          playing: "Playing",
+          silence: "Silence detected..."
+        };
+        statusText.textContent = labels[currentAutoplayState] || currentAutoplayState;
+      }
+
+      // Settings
+      function updateServerName() {
+        const header = document.getElementById("serverName");
+        header.textContent = currentConfig.displayName || "BabelPod";
+      }
+
+      function updateSettingsForm() {
+        document.getElementById("settingsDisplayName").value = currentConfig.displayName || "";
+        document.getElementById("settingsAutoplayEnabled").checked = currentConfig.autoplayEnabled || false;
+        document.getElementById("settingsDefaultVolume").value = currentConfig.defaultVolume || 50;
+        document.getElementById("settingsDefaultVolumeText").textContent = String(currentConfig.defaultVolume || 50);
+
+        // Populate default input select
+        const defaultInputSelect = document.getElementById("settingsDefaultInput");
+        while (defaultInputSelect.firstChild) defaultInputSelect.removeChild(defaultInputSelect.firstChild);
+        availableInputsList.forEach((item) => {
+          const opt = document.createElement("option");
+          opt.value = item.id;
+          opt.textContent = item.name;
+          if (item.id === currentConfig.defaultInputId) opt.selected = true;
+          defaultInputSelect.appendChild(opt);
+        });
+
+        // Populate default outputs checkboxes
+        const defaultOutputsDiv = document.getElementById("settingsDefaultOutputs");
+        while (defaultOutputsDiv.firstChild) defaultOutputsDiv.removeChild(defaultOutputsDiv.firstChild);
+        availableOutputsList.forEach((output) => {
+          const label = document.createElement("label");
+          const checkbox = document.createElement("input");
+          checkbox.type = "checkbox";
+          checkbox.value = output.id;
+          checkbox.checked = (currentConfig.defaultOutputIds || []).includes(output.id);
+          label.appendChild(checkbox);
+          label.appendChild(document.createTextNode(output.name));
+          defaultOutputsDiv.appendChild(label);
+        });
+      }
+
+      document.getElementById("settingsDefaultVolume").addEventListener("input", (ev) => {
+        document.getElementById("settingsDefaultVolumeText").textContent = ev.target.value;
+      });
+
+      function saveSettings() {
+        const defaultOutputCheckboxes = document.getElementById("settingsDefaultOutputs").querySelectorAll("input[type=checkbox]");
+        const selectedDefaultOutputs = [];
+        defaultOutputCheckboxes.forEach((cb) => {
+          if (cb.checked) selectedDefaultOutputs.push(cb.value);
+        });
+
+        socket.emit("setConfig", {
+          displayName: document.getElementById("settingsDisplayName").value,
+          defaultInputId: document.getElementById("settingsDefaultInput").value,
+          defaultOutputIds: selectedDefaultOutputs,
+          defaultVolume: Number(document.getElementById("settingsDefaultVolume").value),
+          autoplayEnabled: document.getElementById("settingsAutoplayEnabled").checked
+        });
+      }
 
       function onOutputCheckChange(e) {
         const cbs = outputsListDiv.querySelectorAll("input[type=checkbox]");

--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
         <label style="margin: 0;">Outputs</label>
         <div id="autoplayControls" style="display: flex; align-items: center; gap: 8px;">
           <span id="autoplayStatusText" style="font-size: 0.8rem; color: #999;"></span>
-          <button id="autoplayButton" class="autoplay-button paused" onclick="toggleAutoplay()"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8.5C6 5.46 8.46 3 11.5 3S17 5.46 17 8.5c0 2.5-1.5 4-2.5 5.5s-1.5 3-1.5 5v1"/><path d="M3 21L21 3" stroke-width="2.5"/></svg></button>
+          <button id="autoplayButton" class="autoplay-button paused" onclick="toggleAutoplay()"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16"><path d="M8.5 1A4.5 4.5 0 0 0 4 5.5v7.047a2.453 2.453 0 0 0 4.75.861l.512-1.363a5.6 5.6 0 0 1 .816-1.46l2.008-2.581A4.34 4.34 0 0 0 8.66 1zM3 5.5A5.5 5.5 0 0 1 8.5 0h.16a5.34 5.34 0 0 1 4.215 8.618l-2.008 2.581a4.6 4.6 0 0 0-.67 1.197l-.51 1.363A3.453 3.453 0 0 1 3 12.547zM8.5 4A1.5 1.5 0 0 0 7 5.5v2.695q.168-.09.332-.192c.327-.208.577-.44.72-.727a.5.5 0 1 1 .895.448c-.256.513-.673.865-1.079 1.123A9 9 0 0 1 7 9.313V11.5a.5.5 0 0 1-1 0v-6a2.5 2.5 0 0 1 5 0V6a.5.5 0 0 1-1 0v-.5A1.5 1.5 0 0 0 8.5 4"/></svg></button>
         </div>
         <span id="autoplayDisabledHint" style="display: none; font-size: 0.75rem; color: #666; cursor: pointer;" onclick="document.querySelector('.settings').open = true;">Enable Autoconnect &rarr;</span>
       </div>
@@ -650,12 +650,12 @@
         const isPaused = currentAutoplayState === "paused";
 
         button.className = "autoplay-button " + (isPaused ? "paused" : "active");
+        const earPath = '<path d="M8.5 1A4.5 4.5 0 0 0 4 5.5v7.047a2.453 2.453 0 0 0 4.75.861l.512-1.363a5.6 5.6 0 0 1 .816-1.46l2.008-2.581A4.34 4.34 0 0 0 8.66 1zM3 5.5A5.5 5.5 0 0 1 8.5 0h.16a5.34 5.34 0 0 1 4.215 8.618l-2.008 2.581a4.6 4.6 0 0 0-.67 1.197l-.51 1.363A3.453 3.453 0 0 1 3 12.547zM8.5 4A1.5 1.5 0 0 0 7 5.5v2.695q.168-.09.332-.192c.327-.208.577-.44.72-.727a.5.5 0 1 1 .895.448c-.256.513-.673.865-1.079 1.123A9 9 0 0 1 7 9.313V11.5a.5.5 0 0 1-1 0v-6a2.5 2.5 0 0 1 5 0V6a.5.5 0 0 1-1 0v-.5A1.5 1.5 0 0 0 8.5 4"/>';
+        const slashLine = '<line x1="1" y1="15" x2="15" y2="1" stroke="currentColor" stroke-width="1.5"/>';
         if (isPaused) {
-          // Ear with slash
-          button.innerHTML = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8.5C6 5.46 8.46 3 11.5 3S17 5.46 17 8.5c0 2.5-1.5 4-2.5 5.5s-1.5 3-1.5 5v1"/><path d="M3 21L21 3" stroke-width="2.5"/></svg>';
+          button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16">${earPath}${slashLine}</svg>`;
         } else {
-          // Ear
-          button.innerHTML = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8.5C6 5.46 8.46 3 11.5 3S17 5.46 17 8.5c0 2.5-1.5 4-2.5 5.5s-1.5 3-1.5 5v1"/></svg>';
+          button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16">${earPath}</svg>`;
         }
         button.style.opacity = isPaused ? "0.5" : "1";
 

--- a/index.html
+++ b/index.html
@@ -142,9 +142,12 @@
       .info {
         background: #1f1f1f;
         margin-top: 1rem;
-        padding: 1rem;
+        padding: 0.5rem 0.75rem;
         border-radius: 6px;
-        font-size: 0.9rem;
+        font-size: 0.85rem;
+      }
+      .info p {
+        margin: 0.25rem 0;
       }
 
       /* Session overlay */
@@ -295,8 +298,10 @@
         <p>Volume: <span id="curVolumeText"></span></p>
         <p>Active Outputs: <span id="activeOutputsSummary"></span></p>
         <ul id="activeOutputs"></ul>
-        <p id="statusMessage" style="color: #4CAF50; margin-top: 1rem;"></p>
-        <p id="errorMessage" style="color: #f44336; margin-top: 0.5rem;"></p>
+        <div style="min-height: 1.5rem; margin-top: 0.5rem;">
+          <p id="statusMessage" style="color: #4CAF50; margin: 0;"></p>
+          <p id="errorMessage" style="color: #f44336; margin: 0;"></p>
+        </div>
       </div>
 
       <details class="settings">
@@ -314,8 +319,8 @@
           <div style="display: flex; align-items: center; justify-content: space-between; margin: 1rem 0 0.25rem;">
             <label style="margin: 0;">Default Outputs</label>
             <label style="display: flex; align-items: center; gap: 0.4rem; margin: 0; font-size: 0.85rem; color: #aaa;">
-              Autoconnect
               <input type="checkbox" id="settingsAutoplayEnabled" style="transform: scale(1.1); accent-color: #fe0000;" />
+              Autoconnect on audio signal
             </label>
           </div>
           <div class="checkbox-list" id="settingsDefaultOutputs"></div>
@@ -406,15 +411,12 @@
             listItem.textContent = outputInfo ? outputInfo.name : outputId;
             activeOutputsUl.appendChild(listItem);
           });
-        } else if (currentConfig.autoplayEnabled && currentAutoplayState !== "paused") {
-          summary.textContent = "None — autoconnect will route to:";
-          (currentConfig.defaultOutputIds || []).forEach((outputId) => {
-            let listItem = document.createElement("li");
-            listItem.style.color = "#888";
+        } else if (currentConfig.autoplayEnabled && (currentConfig.defaultOutputIds || []).length > 0) {
+          const defaultNames = (currentConfig.defaultOutputIds || []).map((outputId) => {
             const outputInfo = availableOutputsList.find(output => output.id === outputId);
-            listItem.textContent = outputInfo ? outputInfo.name : outputId;
-            activeOutputsUl.appendChild(listItem);
+            return outputInfo ? outputInfo.name : outputId;
           });
+          summary.textContent = "None (autoconnect enabled: " + defaultNames.join(", ") + ")";
         } else {
           summary.textContent = "None";
         }

--- a/index.html
+++ b/index.html
@@ -272,13 +272,14 @@
 
       <div style="display: flex; align-items: center; justify-content: space-between; margin: 1rem 0 0.25rem;">
         <label style="margin: 0;">Outputs</label>
-        <div style="display: flex; align-items: center; gap: 8px;">
+        <div id="autoplayControls" style="display: flex; align-items: center; gap: 8px;">
           <span id="autoplayStatusText" style="font-size: 0.8rem; color: #999;"></span>
           <div class="rms-bar-container" style="width: 40px; margin: 0;">
             <div class="rms-bar" id="rmsBar"></div>
           </div>
           <button id="autoplayButton" class="autoplay-button paused" onclick="toggleAutoplay()" style="width: 32px; height: 32px; font-size: 0.9rem;">&#9654;</button>
         </div>
+        <span id="autoplayDisabledHint" style="display: none; font-size: 0.75rem; color: #666; cursor: pointer;" onclick="document.querySelector('.settings').open = true;">Enable autoconnect &rarr;</span>
       </div>
       <div class="checkbox-list" id="outputsList"></div>
 
@@ -572,6 +573,19 @@
       }
 
       function updateAutoplayButton() {
+        const controls = document.getElementById("autoplayControls");
+        const hint = document.getElementById("autoplayDisabledHint");
+        const isEnabled = currentConfig.autoplayEnabled;
+
+        if (!isEnabled && currentAutoplayState === "paused") {
+          controls.style.display = "none";
+          hint.style.display = "";
+          return;
+        }
+
+        controls.style.display = "flex";
+        hint.style.display = "none";
+
         const button = document.getElementById("autoplayButton");
         const statusText = document.getElementById("autoplayStatusText");
         const isPaused = currentAutoplayState === "paused";
@@ -580,11 +594,11 @@
         button.innerHTML = isPaused ? "&#9654;" : "&#10074;&#10074;";
 
         const labels = {
-          paused: "Paused",
-          idle: "Listening...",
-          detecting: "Sound detected...",
-          playing: "Playing",
-          silence: "Silence detected..."
+          paused: "Autoconnect paused",
+          idle: "Autoconnect listening",
+          detecting: "Connecting...",
+          playing: "Connected",
+          silence: "Connected"
         };
         statusText.textContent = labels[currentAutoplayState] || currentAutoplayState;
       }

--- a/index.html
+++ b/index.html
@@ -419,7 +419,7 @@
             const outputInfo = availableOutputsList.find(output => output.id === outputId);
             return outputInfo ? outputInfo.name : outputId;
           });
-          summary.textContent = "Autoconnect: " + defaultNames.join(", ");
+          summary.textContent = "None (Autoconnect: " + defaultNames.join(", ") + ")";
         } else {
           summary.textContent = "None";
         }

--- a/index.html
+++ b/index.html
@@ -196,23 +196,24 @@
         margin-bottom: 0.5rem;
       }
       .autoplay-button {
-        width: 64px;
-        height: 64px;
+        width: 24px;
+        height: 24px;
         border-radius: 50%;
         border: none;
         cursor: pointer;
-        font-size: 1.5rem;
+        font-size: 0.85rem;
         color: white;
         transition: background 0.2s;
+        padding: 0;
+        line-height: 24px;
+        text-align: center;
       }
-      .autoplay-button.active {
-        background: #2e7d32;
-      }
+      .autoplay-button.active,
       .autoplay-button.paused {
-        background: #555;
+        background: transparent;
       }
       .autoplay-button:hover {
-        opacity: 0.85;
+        background: #333;
       }
       .autoplay-status {
         font-size: 0.85rem;
@@ -286,9 +287,9 @@
         <label style="margin: 0;">Outputs</label>
         <div id="autoplayControls" style="display: flex; align-items: center; gap: 8px;">
           <span id="autoplayStatusText" style="font-size: 0.8rem; color: #999;"></span>
-          <button id="autoplayButton" class="autoplay-button paused" onclick="toggleAutoplay()" style="width: 32px; height: 32px; font-size: 0.9rem;">&#9654;</button>
+          <button id="autoplayButton" class="autoplay-button paused" onclick="toggleAutoplay()"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8.5C6 5.46 8.46 3 11.5 3S17 5.46 17 8.5c0 2.5-1.5 4-2.5 5.5s-1.5 3-1.5 5v1"/><path d="M3 21L21 3" stroke-width="2.5"/></svg></button>
         </div>
-        <span id="autoplayDisabledHint" style="display: none; font-size: 0.75rem; color: #666; cursor: pointer;" onclick="document.querySelector('.settings').open = true;">Enable autoconnect &rarr;</span>
+        <span id="autoplayDisabledHint" style="display: none; font-size: 0.75rem; color: #666; cursor: pointer;" onclick="document.querySelector('.settings').open = true;">Enable Autoconnect &rarr;</span>
       </div>
       <div class="checkbox-list" id="outputsList"></div>
 
@@ -412,7 +413,7 @@
             activeOutputsUl.appendChild(listItem);
           });
         } else if (currentConfig.autoplayEnabled && currentAutoplayState === "paused") {
-          summary.textContent = "Autoconnect paused";
+          summary.textContent = "None (Autoconnect paused)";
         } else if (currentConfig.autoplayEnabled && (currentConfig.defaultOutputIds || []).length > 0) {
           const defaultNames = (currentConfig.defaultOutputIds || []).map((outputId) => {
             const outputInfo = availableOutputsList.find(output => output.id === outputId);
@@ -499,6 +500,8 @@
         currentOutputs = s.selectedOutputs;
         currentVolume = s.volume;
         isOwner = (socket.id === s.sessionOwner);
+        if (s.config) currentConfig = s.config;
+        if (s.autoplayState) currentAutoplayState = s.autoplayState;
 
         renderInputsList();
         updateInputSelection();
@@ -510,16 +513,9 @@
         curInputText.textContent = selectedInputInfo ? `${selectedInputInfo.name} (${s.selectedInput})` : s.selectedInput;
         updateSliderProgress();
         updateOverlay();
-
-        if (s.config) {
-          currentConfig = s.config;
-          updateSettingsForm();
-          updateServerName();
-        }
-        if (s.autoplayState) {
-          currentAutoplayState = s.autoplayState;
-          updateAutoplayButton();
-        }
+        updateSettingsForm();
+        updateServerName();
+        updateAutoplayButton();
       });
 
       // Incremental updates
@@ -597,6 +593,7 @@
       socket.on("autoplay", (d) => {
         currentAutoplayState = d.state;
         updateAutoplayButton();
+        renderActiveOutputs();
       });
       socket.on("rmsLevel", (d) => {
         const indicators = inputsList.querySelectorAll(".input-level-indicator");
@@ -608,11 +605,16 @@
             return;
           }
           const isListening = currentAutoplayState !== "paused" && currentConfig.autoplayEnabled;
-          if (!isListening || d.level < 0.001) {
-            // Grey dot — no signal or not listening
+          if (!isListening) {
+            // Dimmed dot — not listening
             indicator.style.width = "6px";
             indicator.style.minWidth = "6px";
-            indicator.style.backgroundColor = "#444";
+            indicator.style.backgroundColor = "#2a2a2a";
+          } else if (d.level < 0.001) {
+            // Grey dot — listening, no signal
+            indicator.style.width = "6px";
+            indicator.style.minWidth = "6px";
+            indicator.style.backgroundColor = "#555";
           } else {
             // Green bar — proportional to signal level
             const widthPx = 6 + Math.min(80, (d.level / 0.3) * 80);
@@ -648,7 +650,14 @@
         const isPaused = currentAutoplayState === "paused";
 
         button.className = "autoplay-button " + (isPaused ? "paused" : "active");
-        button.innerHTML = isPaused ? "&#9654;" : "&#10074;&#10074;";
+        if (isPaused) {
+          // Ear with slash
+          button.innerHTML = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8.5C6 5.46 8.46 3 11.5 3S17 5.46 17 8.5c0 2.5-1.5 4-2.5 5.5s-1.5 3-1.5 5v1"/><path d="M3 21L21 3" stroke-width="2.5"/></svg>';
+        } else {
+          // Ear
+          button.innerHTML = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8.5C6 5.46 8.46 3 11.5 3S17 5.46 17 8.5c0 2.5-1.5 4-2.5 5.5s-1.5 3-1.5 5v1"/></svg>';
+        }
+        button.style.opacity = isPaused ? "0.5" : "1";
 
         const labels = {
           paused: "Autoconnect paused",

--- a/index.html
+++ b/index.html
@@ -411,12 +411,14 @@
             listItem.textContent = outputInfo ? outputInfo.name : outputId;
             activeOutputsUl.appendChild(listItem);
           });
+        } else if (currentConfig.autoplayEnabled && currentAutoplayState === "paused") {
+          summary.textContent = "Autoconnect paused";
         } else if (currentConfig.autoplayEnabled && (currentConfig.defaultOutputIds || []).length > 0) {
           const defaultNames = (currentConfig.defaultOutputIds || []).map((outputId) => {
             const outputInfo = availableOutputsList.find(output => output.id === outputId);
             return outputInfo ? outputInfo.name : outputId;
           });
-          summary.textContent = "None (autoconnect enabled: " + defaultNames.join(", ") + ")";
+          summary.textContent = "Autoconnect: " + defaultNames.join(", ");
         } else {
           summary.textContent = "None";
         }

--- a/index.html
+++ b/index.html
@@ -704,7 +704,7 @@
       function updateSettingsForm() {
         document.getElementById("settingsDisplayName").value = currentConfig.displayName || "";
         document.getElementById("settingsAutoconnectEnabled").checked = currentConfig.autoconnectEnabled || false;
-        document.getElementById("settingsInputMode").value = (currentConfig.autoconnectThreshold || 0.002) >= 0.008 ? "line" : "phono";
+        document.getElementById("settingsInputMode").value = (currentConfig.autoconnectThreshold || 0.005) < 0.002 ? "line" : "phono";
         document.getElementById("settingsDefaultVolume").value = currentConfig.defaultVolume || 50;
         updateSettingsVolumeProgress();
 
@@ -752,7 +752,9 @@
         });
 
         const inputMode = document.getElementById("settingsInputMode").value;
-        const autoconnectThreshold = inputMode === "line" ? 0.01 : 0.002;
+        // Phono mode: signal amplified by preamp (~0.03+ music), higher threshold
+        // Line mode: signal not amplified (~0.002 music), lower threshold
+        const autoconnectThreshold = inputMode === "line" ? 0.0005 : 0.005;
 
         socket.emit("setConfig", {
           displayName: document.getElementById("settingsDisplayName").value,

--- a/index.html
+++ b/index.html
@@ -188,14 +188,14 @@
         background: #666;
       }
 
-      /* Autoplay controls */
-      .autoplay-section {
+      /* Autoconnect controls */
+      .autoconnect-section {
         text-align: center;
         padding: 1rem 0;
         border-bottom: 1px solid #333;
         margin-bottom: 0.5rem;
       }
-      .autoplay-button {
+      .autoconnect-button {
         width: 26px;
         height: 26px;
         border-radius: 50%;
@@ -208,14 +208,14 @@
         align-items: center;
         justify-content: center;
       }
-      .autoplay-button.active,
-      .autoplay-button.paused {
+      .autoconnect-button.active,
+      .autoconnect-button.paused {
         background: transparent;
       }
-      .autoplay-button:hover {
+      .autoconnect-button:hover {
         background: #333;
       }
-      .autoplay-status {
+      .autoconnect-status {
         font-size: 0.85rem;
         color: #999;
         margin-top: 0.5rem;
@@ -285,11 +285,11 @@
 
       <div style="display: flex; align-items: center; justify-content: space-between; margin: 1rem 0 0.25rem;">
         <label style="margin: 0;">Outputs</label>
-        <div id="autoplayControls" style="display: flex; align-items: center; gap: 8px;">
-          <span id="autoplayStatusText" style="font-size: 0.8rem; color: #999;"></span>
-          <button id="autoplayButton" class="autoplay-button paused" onclick="toggleAutoplay()"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M8.5 1A4.5 4.5 0 0 0 4 5.5v7.047a2.453 2.453 0 0 0 4.75.861l.512-1.363a5.6 5.6 0 0 1 .816-1.46l2.008-2.581A4.34 4.34 0 0 0 8.66 1zM3 5.5A5.5 5.5 0 0 1 8.5 0h.16a5.34 5.34 0 0 1 4.215 8.618l-2.008 2.581a4.6 4.6 0 0 0-.67 1.197l-.51 1.363A3.453 3.453 0 0 1 3 12.547zM8.5 4A1.5 1.5 0 0 0 7 5.5v2.695q.168-.09.332-.192c.327-.208.577-.44.72-.727a.5.5 0 1 1 .895.448c-.256.513-.673.865-1.079 1.123A9 9 0 0 1 7 9.313V11.5a.5.5 0 0 1-1 0v-6a2.5 2.5 0 0 1 5 0V6a.5.5 0 0 1-1 0v-.5A1.5 1.5 0 0 0 8.5 4"/></svg></button>
+        <div id="autoconnectControls" style="display: flex; align-items: center; gap: 8px;">
+          <span id="autoconnectStatusText" style="font-size: 0.8rem; color: #999;"></span>
+          <button id="autoconnectButton" class="autoconnect-button paused" onclick="toggleAutoconnect()"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M8.5 1A4.5 4.5 0 0 0 4 5.5v7.047a2.453 2.453 0 0 0 4.75.861l.512-1.363a5.6 5.6 0 0 1 .816-1.46l2.008-2.581A4.34 4.34 0 0 0 8.66 1zM3 5.5A5.5 5.5 0 0 1 8.5 0h.16a5.34 5.34 0 0 1 4.215 8.618l-2.008 2.581a4.6 4.6 0 0 0-.67 1.197l-.51 1.363A3.453 3.453 0 0 1 3 12.547zM8.5 4A1.5 1.5 0 0 0 7 5.5v2.695q.168-.09.332-.192c.327-.208.577-.44.72-.727a.5.5 0 1 1 .895.448c-.256.513-.673.865-1.079 1.123A9 9 0 0 1 7 9.313V11.5a.5.5 0 0 1-1 0v-6a2.5 2.5 0 0 1 5 0V6a.5.5 0 0 1-1 0v-.5A1.5 1.5 0 0 0 8.5 4"/></svg></button>
         </div>
-        <span id="autoplayDisabledHint" style="display: none; font-size: 0.75rem; color: #666; cursor: pointer;" onclick="document.querySelector('.settings').open = true;">Enable Autoconnect &rarr;</span>
+        <span id="autoconnectDisabledHint" style="display: none; font-size: 0.75rem; color: #666; cursor: pointer;" onclick="document.querySelector('.settings').open = true;">Enable Autoconnect &rarr;</span>
       </div>
       <div class="checkbox-list" id="outputsList"></div>
 
@@ -317,10 +317,16 @@
           <label for="settingsDefaultVolume">Default Volume</label>
           <input type="range" min="0" max="100" value="50" id="settingsDefaultVolume" />
 
+          <label>Input Mode</label>
+          <select id="settingsInputMode">
+            <option value="phono">Phono (with preamp)</option>
+            <option value="line">Line</option>
+          </select>
+
           <div style="display: flex; align-items: center; justify-content: space-between; margin: 1rem 0 0.25rem;">
             <label style="margin: 0;">Default Outputs</label>
             <label style="display: flex; align-items: center; gap: 0.4rem; margin: 0; font-size: 0.85rem; color: #aaa;">
-              <input type="checkbox" id="settingsAutoplayEnabled" style="transform: scale(1.1); accent-color: #fe0000;" />
+              <input type="checkbox" id="settingsAutoconnectEnabled" style="transform: scale(1.1); accent-color: #fe0000;" />
               Autoconnect on audio signal
             </label>
           </div>
@@ -363,7 +369,7 @@
       let lastEmittedOutputs = null;
       let lastEmittedInput = null;
       let currentConfig = {};
-      let currentAutoplayState = "paused";
+      let currentAutoconnectState = "paused";
       let availableOutputsList = [];
 
       const inputsList = document.getElementById("inputsList");
@@ -405,16 +411,23 @@
         }
 
         if (currentOutputs.length > 0) {
-          summary.textContent = "";
+          // Determine suffix based on autoconnect state
+          let suffix = "";
+          if (currentAutoconnectState === "connected") {
+            suffix = " (autoconnected)";
+          } else if (currentAutoconnectState === "silence") {
+            suffix = " (idle)";
+          }
+          summary.textContent = suffix;
           currentOutputs.forEach((outputId) => {
             let listItem = document.createElement("li");
             const outputInfo = availableOutputsList.find(output => output.id === outputId);
             listItem.textContent = outputInfo ? outputInfo.name : outputId;
             activeOutputsUl.appendChild(listItem);
           });
-        } else if (currentConfig.autoplayEnabled && currentAutoplayState === "paused") {
+        } else if (currentConfig.autoconnectEnabled && currentAutoconnectState === "paused") {
           summary.textContent = "None (Autoconnect paused)";
-        } else if (currentConfig.autoplayEnabled && (currentConfig.defaultOutputIds || []).length > 0) {
+        } else if (currentConfig.autoconnectEnabled && (currentConfig.defaultOutputIds || []).length > 0) {
           const defaultNames = (currentConfig.defaultOutputIds || []).map((outputId) => {
             const outputInfo = availableOutputsList.find(output => output.id === outputId);
             return outputInfo ? outputInfo.name : outputId;
@@ -501,7 +514,7 @@
         currentVolume = s.volume;
         isOwner = (socket.id === s.sessionOwner);
         if (s.config) currentConfig = s.config;
-        if (s.autoplayState) currentAutoplayState = s.autoplayState;
+        if (s.autoconnectState) currentAutoconnectState = s.autoconnectState;
 
         renderInputsList();
         updateInputSelection();
@@ -515,7 +528,7 @@
         updateOverlay();
         updateSettingsForm();
         updateServerName();
-        updateAutoplayButton();
+        updateAutoconnectButton();
       });
 
       // Incremental updates
@@ -550,6 +563,7 @@
           });
         }
         renderActiveOutputs();
+        updateAutoconnectButton();
       });
       socket.on("volume", (d) => {
         currentVolume = d.value;
@@ -584,15 +598,15 @@
         showError("Connection error: " + error.message);
       });
 
-      // Config and autoplay events
+      // Config and autoconnect events
       socket.on("config", (c) => {
         currentConfig = c;
         updateSettingsForm();
         updateServerName();
       });
-      socket.on("autoplay", (d) => {
-        currentAutoplayState = d.state;
-        updateAutoplayButton();
+      socket.on("autoconnect", (d) => {
+        currentAutoconnectState = d.state;
+        updateAutoconnectButton();
         renderActiveOutputs();
       });
       socket.on("rmsLevel", (d) => {
@@ -604,7 +618,7 @@
             indicator.style.minWidth = "0px";
             return;
           }
-          const isListening = currentAutoplayState !== "paused" && currentConfig.autoplayEnabled;
+          const isListening = currentAutoconnectState !== "paused" && currentConfig.autoconnectEnabled;
           if (!isListening) {
             // Dimmed dot — not listening
             indicator.style.width = "6px";
@@ -625,18 +639,18 @@
         });
       });
 
-      // Autoplay controls
-      function toggleAutoplay() {
-        const newState = currentAutoplayState === "paused" ? "playing" : "paused";
-        socket.emit("setAutoplay", { state: newState });
+      // Autoconnect controls
+      function toggleAutoconnect() {
+        const newState = currentAutoconnectState === "paused" ? "listening" : "paused";
+        socket.emit("setAutoconnect", { state: newState });
       }
 
-      function updateAutoplayButton() {
-        const controls = document.getElementById("autoplayControls");
-        const hint = document.getElementById("autoplayDisabledHint");
-        const isEnabled = currentConfig.autoplayEnabled;
+      function updateAutoconnectButton() {
+        const controls = document.getElementById("autoconnectControls");
+        const hint = document.getElementById("autoconnectDisabledHint");
+        const isEnabled = currentConfig.autoconnectEnabled;
 
-        if (!isEnabled && currentAutoplayState === "paused") {
+        if (!isEnabled && currentAutoconnectState === "paused") {
           controls.style.display = "none";
           hint.style.display = "";
           return;
@@ -645,28 +659,33 @@
         controls.style.display = "flex";
         hint.style.display = "none";
 
-        const button = document.getElementById("autoplayButton");
-        const statusText = document.getElementById("autoplayStatusText");
-        const isPaused = currentAutoplayState === "paused";
+        const button = document.getElementById("autoconnectButton");
+        const statusText = document.getElementById("autoconnectStatusText");
+        const isPaused = currentAutoconnectState === "paused";
 
-        button.className = "autoplay-button " + (isPaused ? "paused" : "active");
+        button.className = "autoconnect-button " + (isPaused ? "paused" : "active");
         const earPath = '<path d="M8.5 1A4.5 4.5 0 0 0 4 5.5v7.047a2.453 2.453 0 0 0 4.75.861l.512-1.363a5.6 5.6 0 0 1 .816-1.46l2.008-2.581A4.34 4.34 0 0 0 8.66 1zM3 5.5A5.5 5.5 0 0 1 8.5 0h.16a5.34 5.34 0 0 1 4.215 8.618l-2.008 2.581a4.6 4.6 0 0 0-.67 1.197l-.51 1.363A3.453 3.453 0 0 1 3 12.547zM8.5 4A1.5 1.5 0 0 0 7 5.5v2.695q.168-.09.332-.192c.327-.208.577-.44.72-.727a.5.5 0 1 1 .895.448c-.256.513-.673.865-1.079 1.123A9 9 0 0 1 7 9.313V11.5a.5.5 0 0 1-1 0v-6a2.5 2.5 0 0 1 5 0V6a.5.5 0 0 1-1 0v-.5A1.5 1.5 0 0 0 8.5 4"/>';
         const slashLine = '<line x1="1" y1="15" x2="15" y2="1" stroke="currentColor" stroke-width="1.5"/>';
+        const isActivelyListening = !isPaused && currentOutputs.length === 0;
         if (isPaused) {
           button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">${earPath}${slashLine}</svg>`;
+          button.style.opacity = "0.5";
         } else {
           button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">${earPath}</svg>`;
+          button.style.opacity = isActivelyListening ? "1" : "0.5";
         }
-        button.style.opacity = isPaused ? "0.5" : "1";
 
-        const labels = {
-          paused: "Autoconnect paused",
-          idle: "Autoconnect listening",
-          detecting: "Connecting...",
-          playing: "Connected",
-          silence: "Connected"
-        };
-        statusText.textContent = labels[currentAutoplayState] || currentAutoplayState;
+        let label;
+        if (isPaused) {
+          label = "Autoconnect paused";
+        } else if (currentAutoconnectState === "detecting") {
+          label = "Connecting...";
+        } else if (currentOutputs.length > 0) {
+          label = "Connected";
+        } else {
+          label = "Autoconnect listening";
+        }
+        statusText.textContent = label;
       }
 
       // Settings
@@ -677,7 +696,8 @@
 
       function updateSettingsForm() {
         document.getElementById("settingsDisplayName").value = currentConfig.displayName || "";
-        document.getElementById("settingsAutoplayEnabled").checked = currentConfig.autoplayEnabled || false;
+        document.getElementById("settingsAutoconnectEnabled").checked = currentConfig.autoconnectEnabled || false;
+        document.getElementById("settingsInputMode").value = (currentConfig.autoconnectThreshold || 0.002) >= 0.008 ? "line" : "phono";
         document.getElementById("settingsDefaultVolume").value = currentConfig.defaultVolume || 50;
         updateSettingsVolumeProgress();
 
@@ -723,12 +743,16 @@
           if (cb.checked) selectedDefaultOutputs.push(cb.value);
         });
 
+        const inputMode = document.getElementById("settingsInputMode").value;
+        const autoconnectThreshold = inputMode === "line" ? 0.01 : 0.002;
+
         socket.emit("setConfig", {
           displayName: document.getElementById("settingsDisplayName").value,
           defaultInputId: document.getElementById("settingsDefaultInput").value,
           defaultOutputIds: selectedDefaultOutputs,
           defaultVolume: Number(document.getElementById("settingsDefaultVolume").value),
-          autoplayEnabled: document.getElementById("settingsAutoplayEnabled").checked
+          autoconnectEnabled: document.getElementById("settingsAutoconnectEnabled").checked,
+          autoconnectThreshold: autoconnectThreshold
         });
       }
 

--- a/index.html
+++ b/index.html
@@ -300,16 +300,15 @@
           <label>Default Input</label>
           <select id="settingsDefaultInput"></select>
 
+          <label for="settingsDefaultVolume">Default Volume</label>
+          <input type="range" min="0" max="100" value="50" id="settingsDefaultVolume" />
+
           <label>Default Outputs</label>
           <div class="checkbox-list" id="settingsDefaultOutputs"></div>
 
-          <label>Default Volume</label>
-          <input type="range" min="0" max="100" value="50" id="settingsDefaultVolume" />
-          <span id="settingsDefaultVolumeText">50</span>
-
           <label style="display: flex; align-items: center; gap: 0.5rem; margin-top: 0.75rem;">
-            <input type="checkbox" id="settingsAutoplayEnabled" style="transform: scale(1.2);" />
-            Autoplay on boot
+            <input type="checkbox" id="settingsAutoplayEnabled" style="transform: scale(1.2); accent-color: #fe0000;" />
+            Autoconnect on audio signal
           </label>
 
           <button class="save-button" onclick="saveSettings()">Save Settings</button>
@@ -600,7 +599,7 @@
         document.getElementById("settingsDisplayName").value = currentConfig.displayName || "";
         document.getElementById("settingsAutoplayEnabled").checked = currentConfig.autoplayEnabled || false;
         document.getElementById("settingsDefaultVolume").value = currentConfig.defaultVolume || 50;
-        document.getElementById("settingsDefaultVolumeText").textContent = String(currentConfig.defaultVolume || 50);
+        updateSettingsVolumeProgress();
 
         // Populate default input select
         const defaultInputSelect = document.getElementById("settingsDefaultInput");
@@ -628,9 +627,14 @@
         });
       }
 
-      document.getElementById("settingsDefaultVolume").addEventListener("input", (ev) => {
-        document.getElementById("settingsDefaultVolumeText").textContent = ev.target.value;
-      });
+      const settingsVolumeRange = document.getElementById("settingsDefaultVolume");
+      function updateSettingsVolumeProgress() {
+        const value = settingsVolumeRange.value;
+        const percentage = (value / 100) * 100;
+        settingsVolumeRange.style.setProperty("--progress", `${percentage}%`);
+      }
+      settingsVolumeRange.addEventListener("input", updateSettingsVolumeProgress);
+      updateSettingsVolumeProgress();
 
       function saveSettings() {
         const defaultOutputCheckboxes = document.getElementById("settingsDefaultOutputs").querySelectorAll("input[type=checkbox]");

--- a/index.html
+++ b/index.html
@@ -196,17 +196,17 @@
         margin-bottom: 0.5rem;
       }
       .autoplay-button {
-        width: 24px;
-        height: 24px;
+        width: 26px;
+        height: 26px;
         border-radius: 50%;
         border: none;
         cursor: pointer;
-        font-size: 0.85rem;
         color: white;
         transition: background 0.2s;
         padding: 0;
-        line-height: 24px;
-        text-align: center;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
       }
       .autoplay-button.active,
       .autoplay-button.paused {
@@ -287,7 +287,7 @@
         <label style="margin: 0;">Outputs</label>
         <div id="autoplayControls" style="display: flex; align-items: center; gap: 8px;">
           <span id="autoplayStatusText" style="font-size: 0.8rem; color: #999;"></span>
-          <button id="autoplayButton" class="autoplay-button paused" onclick="toggleAutoplay()"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16"><path d="M8.5 1A4.5 4.5 0 0 0 4 5.5v7.047a2.453 2.453 0 0 0 4.75.861l.512-1.363a5.6 5.6 0 0 1 .816-1.46l2.008-2.581A4.34 4.34 0 0 0 8.66 1zM3 5.5A5.5 5.5 0 0 1 8.5 0h.16a5.34 5.34 0 0 1 4.215 8.618l-2.008 2.581a4.6 4.6 0 0 0-.67 1.197l-.51 1.363A3.453 3.453 0 0 1 3 12.547zM8.5 4A1.5 1.5 0 0 0 7 5.5v2.695q.168-.09.332-.192c.327-.208.577-.44.72-.727a.5.5 0 1 1 .895.448c-.256.513-.673.865-1.079 1.123A9 9 0 0 1 7 9.313V11.5a.5.5 0 0 1-1 0v-6a2.5 2.5 0 0 1 5 0V6a.5.5 0 0 1-1 0v-.5A1.5 1.5 0 0 0 8.5 4"/></svg></button>
+          <button id="autoplayButton" class="autoplay-button paused" onclick="toggleAutoplay()"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M8.5 1A4.5 4.5 0 0 0 4 5.5v7.047a2.453 2.453 0 0 0 4.75.861l.512-1.363a5.6 5.6 0 0 1 .816-1.46l2.008-2.581A4.34 4.34 0 0 0 8.66 1zM3 5.5A5.5 5.5 0 0 1 8.5 0h.16a5.34 5.34 0 0 1 4.215 8.618l-2.008 2.581a4.6 4.6 0 0 0-.67 1.197l-.51 1.363A3.453 3.453 0 0 1 3 12.547zM8.5 4A1.5 1.5 0 0 0 7 5.5v2.695q.168-.09.332-.192c.327-.208.577-.44.72-.727a.5.5 0 1 1 .895.448c-.256.513-.673.865-1.079 1.123A9 9 0 0 1 7 9.313V11.5a.5.5 0 0 1-1 0v-6a2.5 2.5 0 0 1 5 0V6a.5.5 0 0 1-1 0v-.5A1.5 1.5 0 0 0 8.5 4"/></svg></button>
         </div>
         <span id="autoplayDisabledHint" style="display: none; font-size: 0.75rem; color: #666; cursor: pointer;" onclick="document.querySelector('.settings').open = true;">Enable Autoconnect &rarr;</span>
       </div>
@@ -653,9 +653,9 @@
         const earPath = '<path d="M8.5 1A4.5 4.5 0 0 0 4 5.5v7.047a2.453 2.453 0 0 0 4.75.861l.512-1.363a5.6 5.6 0 0 1 .816-1.46l2.008-2.581A4.34 4.34 0 0 0 8.66 1zM3 5.5A5.5 5.5 0 0 1 8.5 0h.16a5.34 5.34 0 0 1 4.215 8.618l-2.008 2.581a4.6 4.6 0 0 0-.67 1.197l-.51 1.363A3.453 3.453 0 0 1 3 12.547zM8.5 4A1.5 1.5 0 0 0 7 5.5v2.695q.168-.09.332-.192c.327-.208.577-.44.72-.727a.5.5 0 1 1 .895.448c-.256.513-.673.865-1.079 1.123A9 9 0 0 1 7 9.313V11.5a.5.5 0 0 1-1 0v-6a2.5 2.5 0 0 1 5 0V6a.5.5 0 0 1-1 0v-.5A1.5 1.5 0 0 0 8.5 4"/>';
         const slashLine = '<line x1="1" y1="15" x2="15" y2="1" stroke="currentColor" stroke-width="1.5"/>';
         if (isPaused) {
-          button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16">${earPath}${slashLine}</svg>`;
+          button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">${earPath}${slashLine}</svg>`;
         } else {
-          button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16">${earPath}</svg>`;
+          button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">${earPath}</svg>`;
         }
         button.style.opacity = isPaused ? "0.5" : "1";
 

--- a/index.html
+++ b/index.html
@@ -281,7 +281,10 @@
       <div class="radio-list" id="inputsList"></div>
 
       <label for="outputVolume">Volume</label>
-      <input type="range" min="0" max="100" value="50" id="outputVolume" />
+      <div style="display: flex; align-items: center; gap: 8px;">
+        <input type="range" min="0" max="100" value="50" id="outputVolume" style="flex: 1;" />
+        <span id="volumeLabel" style="font-size: 0.85rem; color: #999; min-width: 35px; text-align: right;">50%</span>
+      </div>
 
       <div style="display: flex; align-items: center; justify-content: space-between; margin: 1rem 0 0.25rem;">
         <label style="margin: 0;">Outputs</label>
@@ -314,14 +317,17 @@
           <label>Default Input</label>
           <select id="settingsDefaultInput"></select>
 
-          <label for="settingsDefaultVolume">Default Volume</label>
-          <input type="range" min="0" max="100" value="50" id="settingsDefaultVolume" />
-
           <label>Input Mode</label>
           <select id="settingsInputMode">
             <option value="phono">Phono (with preamp)</option>
             <option value="line">Line</option>
           </select>
+
+          <label for="settingsDefaultVolume">Default Volume</label>
+          <div style="display: flex; align-items: center; gap: 8px;">
+            <input type="range" min="0" max="100" value="50" id="settingsDefaultVolume" style="flex: 1;" />
+            <span id="settingsVolumeLabel" style="font-size: 0.85rem; color: #999; min-width: 35px; text-align: right;">50%</span>
+          </div>
 
           <div style="display: flex; align-items: center; justify-content: space-between; margin: 1rem 0 0.25rem;">
             <label style="margin: 0;">Default Outputs</label>
@@ -352,6 +358,7 @@
         const max = rangeInput.max || 100;
         const percentage = (value / max) * 100;
         rangeInput.style.setProperty("--progress", `${percentage}%`);
+        document.getElementById("volumeLabel").textContent = value + "%";
       }
 
       rangeInput.addEventListener("input", updateSliderProgress);
@@ -521,7 +528,7 @@
         renderOutputsList(s.outputs);
         renderActiveOutputs();
         volumeRange.value = s.volume;
-        curVolumeText.textContent = String(s.volume);
+        curVolumeText.textContent = s.volume + "%";
         const selectedInputInfo = s.inputs.find(input => input.id === s.selectedInput);
         curInputText.textContent = selectedInputInfo ? `${selectedInputInfo.name} (${s.selectedInput})` : s.selectedInput;
         updateSliderProgress();
@@ -567,7 +574,7 @@
       });
       socket.on("volume", (d) => {
         currentVolume = d.value;
-        curVolumeText.textContent = String(d.value);
+        curVolumeText.textContent = d.value + "%";
         if (!isUserDraggingVolume && d.value !== lastEmittedVolume) {
           volumeRange.value = d.value;
           updateSliderProgress();
@@ -732,6 +739,7 @@
         const value = settingsVolumeRange.value;
         const percentage = (value / 100) * 100;
         settingsVolumeRange.style.setProperty("--progress", `${percentage}%`);
+        document.getElementById("settingsVolumeLabel").textContent = value + "%";
       }
       settingsVolumeRange.addEventListener("input", updateSettingsVolumeProgress);
       updateSettingsVolumeProgress();

--- a/index.html
+++ b/index.html
@@ -338,7 +338,7 @@
           </div>
           <div class="checkbox-list" id="settingsDefaultOutputs"></div>
 
-          <button class="save-button" onclick="saveSettings()">Save Settings</button>
+          <button class="save-button" id="saveSettingsButton" onclick="saveSettings()">Save Settings</button>
         </div>
       </details>
     </div>
@@ -610,6 +610,17 @@
         currentConfig = c;
         updateSettingsForm();
         updateServerName();
+
+        if (waitingForConfigConfirmation) {
+          waitingForConfigConfirmation = false;
+          if (saveConfirmationTimeout) clearTimeout(saveConfirmationTimeout);
+          const saveButton = document.getElementById("saveSettingsButton");
+          saveButton.textContent = "Saved ✓";
+          saveButton.disabled = false;
+          setTimeout(() => {
+            saveButton.textContent = "Save Settings";
+          }, 2000);
+        }
       });
       socket.on("autoconnect", (d) => {
         currentAutoconnectState = d.state;
@@ -756,6 +767,22 @@
         // Line mode: signal not amplified (~0.002 music), lower threshold
         const autoconnectThreshold = inputMode === "line" ? 0.0005 : 0.01;
 
+        const saveButton = document.getElementById("saveSettingsButton");
+        saveButton.textContent = "Saving...";
+        saveButton.disabled = true;
+        waitingForConfigConfirmation = true;
+
+        // Timeout if server doesn't respond
+        if (saveConfirmationTimeout) clearTimeout(saveConfirmationTimeout);
+        saveConfirmationTimeout = setTimeout(() => {
+          if (waitingForConfigConfirmation) {
+            waitingForConfigConfirmation = false;
+            saveButton.textContent = "Save failed";
+            saveButton.disabled = false;
+            setTimeout(() => { saveButton.textContent = "Save Settings"; }, 3000);
+          }
+        }, 5000);
+
         socket.emit("setConfig", {
           displayName: document.getElementById("settingsDisplayName").value,
           defaultInputId: document.getElementById("settingsDefaultInput").value,
@@ -765,6 +792,9 @@
           autoconnectThreshold: autoconnectThreshold
         });
       }
+
+      let waitingForConfigConfirmation = false;
+      let saveConfirmationTimeout = null;
 
       function onOutputCheckChange(e) {
         const cbs = outputsListDiv.querySelectorAll("input[type=checkbox]");

--- a/index.html
+++ b/index.html
@@ -125,6 +125,15 @@
         background: #2f2222;
         border: 1px solid #662222;
       }
+      .input-level-indicator {
+        display: inline-block;
+        margin-left: auto;
+        height: 6px;
+        min-width: 6px;
+        border-radius: 3px;
+        background: #444;
+        transition: width 0.1s linear, background-color 0.2s;
+      }
       .checkbox-list input[type="checkbox"] {
         margin-right: 0.5rem;
         transform: scale(1.2);
@@ -274,9 +283,6 @@
         <label style="margin: 0;">Outputs</label>
         <div id="autoplayControls" style="display: flex; align-items: center; gap: 8px;">
           <span id="autoplayStatusText" style="font-size: 0.8rem; color: #999;"></span>
-          <div class="rms-bar-container" style="width: 40px; margin: 0;">
-            <div class="rms-bar" id="rmsBar"></div>
-          </div>
           <button id="autoplayButton" class="autoplay-button paused" onclick="toggleAutoplay()" style="width: 32px; height: 32px; font-size: 0.9rem;">&#9654;</button>
         </div>
         <span id="autoplayDisabledHint" style="display: none; font-size: 0.75rem; color: #666; cursor: pointer;" onclick="document.querySelector('.settings').open = true;">Enable autoconnect &rarr;</span>
@@ -284,9 +290,10 @@
       <div class="checkbox-list" id="outputsList"></div>
 
       <div class="info">
-        <p>Current Input: <span id="curInputText"></span></p>
-        <p>Current Volume: <span id="curVolumeText"></span></p>
-        <p>Active Outputs:</p>
+        <label style="font-size: 1rem;">Status</label>
+        <p>Input: <span id="curInputText"></span></p>
+        <p>Volume: <span id="curVolumeText"></span></p>
+        <p>Active Outputs: <span id="activeOutputsSummary"></span></p>
         <ul id="activeOutputs"></ul>
         <p id="statusMessage" style="color: #4CAF50; margin-top: 1rem;"></p>
         <p id="errorMessage" style="color: #f44336; margin-top: 0.5rem;"></p>
@@ -304,13 +311,14 @@
           <label for="settingsDefaultVolume">Default Volume</label>
           <input type="range" min="0" max="100" value="50" id="settingsDefaultVolume" />
 
-          <label>Default Outputs</label>
+          <div style="display: flex; align-items: center; justify-content: space-between; margin: 1rem 0 0.25rem;">
+            <label style="margin: 0;">Default Outputs</label>
+            <label style="display: flex; align-items: center; gap: 0.4rem; margin: 0; font-size: 0.85rem; color: #aaa;">
+              Autoconnect
+              <input type="checkbox" id="settingsAutoplayEnabled" style="transform: scale(1.1); accent-color: #fe0000;" />
+            </label>
+          </div>
           <div class="checkbox-list" id="settingsDefaultOutputs"></div>
-
-          <label style="display: flex; align-items: center; gap: 0.5rem; margin-top: 0.75rem;">
-            <input type="checkbox" id="settingsAutoplayEnabled" style="transform: scale(1.2); accent-color: #fe0000;" />
-            Autoconnect on audio signal
-          </label>
 
           <button class="save-button" onclick="saveSettings()">Save Settings</button>
         </div>
@@ -385,14 +393,31 @@
       }
 
       function renderActiveOutputs() {
+        const summary = document.getElementById("activeOutputsSummary");
         while (activeOutputsUl.firstChild) {
           activeOutputsUl.removeChild(activeOutputsUl.firstChild);
         }
-        currentOutputs.forEach((o) => {
-          let li = document.createElement("li");
-          li.textContent = o;
-          activeOutputsUl.appendChild(li);
-        });
+
+        if (currentOutputs.length > 0) {
+          summary.textContent = "";
+          currentOutputs.forEach((outputId) => {
+            let listItem = document.createElement("li");
+            const outputInfo = availableOutputsList.find(output => output.id === outputId);
+            listItem.textContent = outputInfo ? outputInfo.name : outputId;
+            activeOutputsUl.appendChild(listItem);
+          });
+        } else if (currentConfig.autoplayEnabled && currentAutoplayState !== "paused") {
+          summary.textContent = "None — autoconnect will route to:";
+          (currentConfig.defaultOutputIds || []).forEach((outputId) => {
+            let listItem = document.createElement("li");
+            listItem.style.color = "#888";
+            const outputInfo = availableOutputsList.find(output => output.id === outputId);
+            listItem.textContent = outputInfo ? outputInfo.name : outputId;
+            activeOutputsUl.appendChild(listItem);
+          });
+        } else {
+          summary.textContent = "None";
+        }
       }
 
       // Overlay logic
@@ -431,6 +456,14 @@
           r.addEventListener("change", onInputRadioChange);
           lb.appendChild(r);
           lb.appendChild(document.createTextNode(item.name));
+
+          // Level indicator dot/bar for selected input
+          const indicator = document.createElement("span");
+          indicator.className = "input-level-indicator";
+          indicator.dataset.inputId = item.id;
+          indicator.title = "Audio input level";
+          lb.appendChild(indicator);
+
           if (item.id === currentInput) lb.classList.add("selected");
           inputsList.appendChild(lb);
         });
@@ -469,7 +502,8 @@
         renderActiveOutputs();
         volumeRange.value = s.volume;
         curVolumeText.textContent = String(s.volume);
-        curInputText.textContent = s.selectedInput;
+        const selectedInputInfo = s.inputs.find(input => input.id === s.selectedInput);
+        curInputText.textContent = selectedInputInfo ? `${selectedInputInfo.name} (${s.selectedInput})` : s.selectedInput;
         updateSliderProgress();
         updateOverlay();
 
@@ -496,7 +530,8 @@
       });
       socket.on("input", (d) => {
         currentInput = d.id;
-        curInputText.textContent = d.id;
+        const switchedInputInfo = availableInputsList.find(input => input.id === d.id);
+        curInputText.textContent = switchedInputInfo ? `${switchedInputInfo.name} (${d.id})` : d.id;
         if (d.id !== lastEmittedInput) {
           const radio = inputsList.querySelector(`input[value="${CSS.escape(d.id)}"]`);
           if (radio) radio.checked = true;
@@ -560,10 +595,28 @@
         updateAutoplayButton();
       });
       socket.on("rmsLevel", (d) => {
-        const rmsBar = document.getElementById("rmsBar");
-        // Scale RMS for visibility (0-0.3 range mapped to 0-100%)
-        const widthPercent = Math.min(100, (d.level / 0.3) * 100);
-        rmsBar.style.width = widthPercent + "%";
+        const indicators = inputsList.querySelectorAll(".input-level-indicator");
+        indicators.forEach((indicator) => {
+          const isSelected = indicator.dataset.inputId === currentInput;
+          if (!isSelected) {
+            indicator.style.width = "0px";
+            indicator.style.minWidth = "0px";
+            return;
+          }
+          const isListening = currentAutoplayState !== "paused" && currentConfig.autoplayEnabled;
+          if (!isListening || d.level < 0.001) {
+            // Grey dot — no signal or not listening
+            indicator.style.width = "6px";
+            indicator.style.minWidth = "6px";
+            indicator.style.backgroundColor = "#444";
+          } else {
+            // Green bar — proportional to signal level
+            const widthPx = 6 + Math.min(80, (d.level / 0.3) * 80);
+            indicator.style.width = widthPx + "px";
+            indicator.style.minWidth = "6px";
+            indicator.style.backgroundColor = "#4CAF50";
+          }
+        });
       });
 
       // Autoplay controls

--- a/index.html
+++ b/index.html
@@ -264,21 +264,22 @@
   <body>
     <header id="serverName">BabelPod</header>
     <div class="container">
-      <div class="autoplay-section">
-        <button id="autoplayButton" class="autoplay-button paused" onclick="toggleAutoplay()">&#9654;</button>
-        <div class="autoplay-status" id="autoplayStatusText">Paused</div>
-        <div class="rms-bar-container">
-          <div class="rms-bar" id="rmsBar"></div>
-        </div>
-      </div>
-
       <label>Input Device</label>
       <div class="radio-list" id="inputsList"></div>
 
       <label for="outputVolume">Volume</label>
       <input type="range" min="0" max="100" value="50" id="outputVolume" />
 
-      <label>Outputs</label>
+      <div style="display: flex; align-items: center; justify-content: space-between; margin: 1rem 0 0.25rem;">
+        <label style="margin: 0;">Outputs</label>
+        <div style="display: flex; align-items: center; gap: 8px;">
+          <span id="autoplayStatusText" style="font-size: 0.8rem; color: #999;"></span>
+          <div class="rms-bar-container" style="width: 40px; margin: 0;">
+            <div class="rms-bar" id="rmsBar"></div>
+          </div>
+          <button id="autoplayButton" class="autoplay-button paused" onclick="toggleAutoplay()" style="width: 32px; height: 32px; font-size: 0.9rem;">&#9654;</button>
+        </div>
+      </div>
       <div class="checkbox-list" id="outputsList"></div>
 
       <div class="info">

--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ const DEFAULT_CONFIG = {
   defaultInputId: null,
   defaultOutputIds: [],
   defaultVolume: 50,
-  autoplayEnabled: false,
-  autoplayThreshold: 0.002
+  autoconnectEnabled: false,
+  autoconnectThreshold: 0.002
 };
 
 let config = { ...DEFAULT_CONFIG };
@@ -112,8 +112,8 @@ class RmsMonitorTransform extends stream.Transform {
   }
 
   _transform(chunk, encoding, callback) {
-    // Skip RMS calculation when autoplay is paused (save CPU)
-    if (autoplayState.state === 'paused') {
+    // Skip RMS calculation when autoconnect is paused (save CPU)
+    if (autoconnectState.state === 'paused') {
       callback(null, chunk);
       return;
     }
@@ -145,25 +145,25 @@ let rmsMonitor = new RmsMonitorTransform();
 let lastRmsEmitTime = 0;
 
 // =======================
-// 4c) Autoplay state machine
+// 4c) Autoconnect state machine
 // =======================
-const AUTOPLAY_DETECT_SUSTAIN_MS = 250;
-const AUTOPLAY_SILENCE_TIMEOUT_MS = 300000; // 5 minutes
+const AUTOCONNECT_DETECT_SUSTAIN_MS = 250;
+const AUTOCONNECT_SILENCE_TIMEOUT_MS = 300000; // 5 minutes
 
-let autoplayState = {
-  state: config.autoplayEnabled ? 'idle' : 'paused',
+let autoconnectState = {
+  state: config.autoconnectEnabled ? 'idle' : 'paused',
   detectingSince: null,
   silenceSince: null,
 };
 
-function emitAutoplayState() {
-  io.emit('autoplay', { state: autoplayState.state });
+function emitAutoconnectState() {
+  io.emit('autoconnect', { state: autoconnectState.state });
 }
 
 function activateDefaultOutputs() {
   if (config.defaultOutputIds.length === 0) {
-    io.emit('status', { message: 'Autoplay: no default outputs configured' });
-    console.log("Autoplay: no default outputs configured");
+    io.emit('status', { message: 'Autoconnect: no default outputs configured' });
+    console.log("Autoconnect: no default outputs configured");
     return;
   }
 
@@ -177,101 +177,101 @@ function activateDefaultOutputs() {
     io.emit('volume', { value: volume });
     const missing = config.defaultOutputIds.length - validOutputIds.length;
     const message = missing > 0
-      ? `Autoplay activated (${missing} default output${missing > 1 ? 's' : ''} unavailable)`
-      : 'Autoplay activated';
+      ? `Autoconnect activated (${missing} default output${missing > 1 ? 's' : ''} unavailable)`
+      : 'Autoconnect activated';
     io.emit('status', { message });
-    console.log("Autoplay: activated default outputs:", validOutputIds);
+    console.log("Autoconnect: activated default outputs:", validOutputIds);
   } else {
-    io.emit('serverError', { message: 'Autoplay: default outputs not available' });
-    console.log("Autoplay: all default outputs unavailable:", config.defaultOutputIds);
+    io.emit('serverError', { message: 'Autoconnect: default outputs not available' });
+    console.log("Autoconnect: all default outputs unavailable:", config.defaultOutputIds);
   }
 }
 
 function deactivateOutputs() {
   syncOutputs([]);
   io.emit('output', { ids: [] });
-  io.emit('status', { message: 'Autoplay: speakers released after silence' });
-  console.log("Autoplay: deactivated outputs after silence timeout");
+  io.emit('status', { message: 'Autoconnect: speakers released after silence' });
+  console.log("Autoconnect: deactivated outputs after silence timeout");
 }
 
-function tickAutoplay(rmsLevel) {
-  const threshold = config.autoplayThreshold || 0.002;
+function tickAutoconnect(rmsLevel) {
+  const threshold = config.autoconnectThreshold || 0.002;
   const now = Date.now();
 
-  switch (autoplayState.state) {
+  switch (autoconnectState.state) {
     case 'paused':
       return; // Do nothing
 
     case 'idle':
       if (rmsLevel > threshold) {
-        autoplayState.state = 'detecting';
-        autoplayState.detectingSince = now;
-        emitAutoplayState();
+        autoconnectState.state = 'detecting';
+        autoconnectState.detectingSince = now;
+        emitAutoconnectState();
       }
       break;
 
     case 'detecting':
       if (rmsLevel <= threshold) {
         // Signal dropped — false trigger
-        autoplayState.state = 'idle';
-        autoplayState.detectingSince = null;
-        emitAutoplayState();
-      } else if (now - autoplayState.detectingSince >= AUTOPLAY_DETECT_SUSTAIN_MS) {
+        autoconnectState.state = 'idle';
+        autoconnectState.detectingSince = null;
+        emitAutoconnectState();
+      } else if (now - autoconnectState.detectingSince >= AUTOCONNECT_DETECT_SUSTAIN_MS) {
         // Sustained signal — activate!
-        autoplayState.state = 'playing';
-        autoplayState.detectingSince = null;
-        emitAutoplayState();
+        autoconnectState.state = 'connected';
+        autoconnectState.detectingSince = null;
+        emitAutoconnectState();
         activateDefaultOutputs();
       }
       break;
 
-    case 'playing':
+    case 'connected':
       if (rmsLevel <= threshold) {
-        autoplayState.state = 'silence';
-        autoplayState.silenceSince = now;
-        emitAutoplayState();
+        autoconnectState.state = 'silence';
+        autoconnectState.silenceSince = now;
+        emitAutoconnectState();
       }
       break;
 
     case 'silence':
       if (rmsLevel > threshold) {
         // Sound returned
-        autoplayState.state = 'playing';
-        autoplayState.silenceSince = null;
-        emitAutoplayState();
-      } else if (now - autoplayState.silenceSince >= AUTOPLAY_SILENCE_TIMEOUT_MS) {
+        autoconnectState.state = 'connected';
+        autoconnectState.silenceSince = null;
+        emitAutoconnectState();
+      } else if (now - autoconnectState.silenceSince >= AUTOCONNECT_SILENCE_TIMEOUT_MS) {
         // Extended silence — release speakers
-        autoplayState.state = 'idle';
-        autoplayState.silenceSince = null;
-        emitAutoplayState();
+        autoconnectState.state = 'idle';
+        autoconnectState.silenceSince = null;
+        emitAutoconnectState();
         deactivateOutputs();
       }
       break;
   }
 }
 
-function setAutoplayState(newState) {
+function setAutoconnectState(newState) {
   if (newState === 'paused') {
-    autoplayState.state = 'paused';
-    autoplayState.detectingSince = null;
-    autoplayState.silenceSince = null;
+    autoconnectState.state = 'paused';
+    autoconnectState.detectingSince = null;
+    autoconnectState.silenceSince = null;
     // Master kill switch — stop all outputs
     syncOutputs([]);
     io.emit('output', { ids: [] });
-    emitAutoplayState();
-    console.log("Autoplay: paused (all outputs stopped)");
-  } else if (newState === 'playing') {
-    autoplayState.state = 'idle'; // Enter idle, let RMS detection handle the rest
-    autoplayState.detectingSince = null;
-    autoplayState.silenceSince = null;
-    emitAutoplayState();
-    console.log("Autoplay: armed and listening");
+    emitAutoconnectState();
+    console.log("Autoconnect: paused (all outputs stopped)");
+  } else if (newState === 'listening') {
+    autoconnectState.state = 'idle'; // Enter idle, let RMS detection handle the rest
+    autoconnectState.detectingSince = null;
+    autoconnectState.silenceSince = null;
+    emitAutoconnectState();
+    console.log("Autoconnect: armed and listening");
   }
 }
 
-// Hook RMS readings into autoplay state machine
+// Hook RMS readings into autoconnect state machine
 function wireRmsMonitor() {
-  rmsMonitor.on('rms', tickAutoplay);
+  rmsMonitor.on('rms', tickAutoconnect);
 }
 wireRmsMonitor();
 
@@ -589,7 +589,7 @@ function buildStatePayload() {
     selectedOutputs,
     volume,
     config,
-    autoplayState: autoplayState.state
+    autoconnectState: autoconnectState.state
   };
 }
 
@@ -1077,7 +1077,7 @@ io.on('connection', socket => {
     const oldDisplayName = config.displayName;
 
     // Only allow known fields
-    const allowedFields = ['displayName', 'defaultInputId', 'defaultOutputIds', 'defaultVolume', 'autoplayEnabled', 'autoplayThreshold'];
+    const allowedFields = ['displayName', 'defaultInputId', 'defaultOutputIds', 'defaultVolume', 'autoconnectEnabled', 'autoconnectThreshold'];
     const filtered = {};
     for (const key of allowedFields) {
       if (key in data) filtered[key] = data[key];
@@ -1092,13 +1092,13 @@ io.on('connection', socket => {
     io.emit('status', { message: 'Settings saved' });
   });
 
-  socket.on('setAutoplay', (data) => {
+  socket.on('setAutoconnect', (data) => {
     if (socket.id !== sessionOwner) return;
     const newState = data?.state;
-    if (newState !== 'playing' && newState !== 'paused') return;
+    if (newState !== 'listening' && newState !== 'paused') return;
 
-    console.log("Setting autoplay state:", newState);
-    setAutoplayState(newState);
+    console.log("Setting autoconnect state:", newState);
+    setAutoconnectState(newState);
   });
 
   socket.on('disconnect', () => {

--- a/index.js
+++ b/index.js
@@ -269,8 +269,10 @@ function tickAutoconnect(rmsLevel) {
       break;
 
     case 'connected':
-      if (rmsLevel <= threshold) {
-        logStateTransition('connected', 'silence', rmsLevel, `below threshold`);
+      // Hysteresis: only leave connected when RMS drops well below start threshold
+      // This prevents rapid flip-flopping during quiet music passages
+      if (rmsLevel <= threshold / 4) {
+        logStateTransition('connected', 'silence', rmsLevel, `below stop threshold ${(threshold/4).toFixed(4)}`);
         autoconnectState.state = 'silence';
         autoconnectState.silenceSince = now;
         emitAutoconnectState();
@@ -283,6 +285,11 @@ function tickAutoconnect(rmsLevel) {
         autoconnectState.state = 'connected';
         autoconnectState.silenceSince = null;
         emitAutoconnectState();
+        // If outputs were manually cleared while in silence, re-activate defaults
+        if (selectedOutputs.length === 0) {
+          log.info('[autoconnect] outputs were cleared during silence; re-activating defaults');
+          activateDefaultOutputs();
+        }
       } else if (now - autoconnectState.silenceSince >= AUTOCONNECT_SILENCE_TIMEOUT_MS) {
         const silentFor = now - autoconnectState.silenceSince;
         logStateTransition('silence', 'idle', rmsLevel, `silent for ${Math.round(silentFor/1000)}s`);

--- a/index.js
+++ b/index.js
@@ -21,6 +21,20 @@ const { hostname } = require('os');
 const path = require('path');
 
 // =======================
+// 1a) Log level
+// =======================
+// LOG_LEVEL env var: debug | info | warn | error (default: info)
+const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
+const currentLogLevel = LOG_LEVELS[(process.env.LOG_LEVEL || 'info').toLowerCase()] ?? LOG_LEVELS.info;
+const log = {
+  debug: (...args) => { if (currentLogLevel <= LOG_LEVELS.debug) console.log(...args); },
+  info: (...args) => { if (currentLogLevel <= LOG_LEVELS.info) console.log(...args); },
+  warn: (...args) => { if (currentLogLevel <= LOG_LEVELS.warn) console.warn(...args); },
+  error: (...args) => { if (currentLogLevel <= LOG_LEVELS.error) console.error(...args); },
+};
+log.info(`Log level: ${process.env.LOG_LEVEL || 'info'}`);
+
+// =======================
 // 1b) Instance configuration
 // =======================
 const CONFIG_PATH = path.join(__dirname, 'babelpod.config.json');
@@ -210,7 +224,7 @@ let maxRmsSinceLastLog = 0;
 const RMS_LOG_INTERVAL_MS = 10000; // every 10 seconds
 
 function logStateTransition(fromState, toState, rmsLevel, reason) {
-  console.log(`[autoconnect] ${fromState} → ${toState} (rms=${rmsLevel.toFixed(4)}, reason=${reason})`);
+  log.info(`[autoconnect] ${fromState} → ${toState} (rms=${rmsLevel.toFixed(4)}, reason=${reason})`);
 }
 
 function tickAutoconnect(rmsLevel) {
@@ -220,7 +234,7 @@ function tickAutoconnect(rmsLevel) {
   // Periodic RMS sample logging
   if (rmsLevel > maxRmsSinceLastLog) maxRmsSinceLastLog = rmsLevel;
   if (now - lastRmsLogTime >= RMS_LOG_INTERVAL_MS) {
-    console.log(`[autoconnect] state=${autoconnectState.state} threshold=${threshold} peak_rms=${maxRmsSinceLastLog.toFixed(4)} current_rms=${rmsLevel.toFixed(4)}`);
+    log.debug(`[autoconnect] state=${autoconnectState.state} threshold=${threshold} peak_rms=${maxRmsSinceLastLog.toFixed(4)} current_rms=${rmsLevel.toFixed(4)}`);
     lastRmsLogTime = now;
     maxRmsSinceLastLog = 0;
   }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,52 @@ const mdns = require('mdns-js');
 const dnssd = require('dnssd2');
 const AirTunes = require('airtunes2');
 const { hostname } = require('os');
+const path = require('path');
+
+// =======================
+// 1b) Instance configuration
+// =======================
+const CONFIG_PATH = path.join(__dirname, 'babelpod.config.json');
+
+const DEFAULT_CONFIG = {
+  displayName: hostname().replace('.local', ''),
+  defaultInputId: null,
+  defaultOutputIds: [],
+  defaultVolume: 50,
+  autoplayEnabled: false,
+  autoplayThreshold: 0.002
+};
+
+let config = { ...DEFAULT_CONFIG };
+
+function loadConfig() {
+  try {
+    const data = fs.readFileSync(CONFIG_PATH, 'utf8');
+    const parsed = JSON.parse(data);
+    config = { ...DEFAULT_CONFIG, ...parsed };
+    console.log("Loaded config:", config);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.log("No config file found, using defaults");
+    } else {
+      console.error("Error reading config file, using defaults:", error.message);
+    }
+    config = { ...DEFAULT_CONFIG };
+  }
+}
+
+function saveConfig(partial) {
+  config = { ...config, ...partial };
+  try {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+    console.log("Config saved:", config);
+  } catch (error) {
+    console.error("Error saving config:", error.message);
+  }
+  io.emit('config', config);
+}
+
+loadConfig();
 
 // Bluetooth support - optional, may not be available on all systems
 let blue = null;
@@ -56,6 +102,168 @@ DiscardSink.prototype._write = function (_chunk, _enc, cb) {
 const fallbackSink = new DiscardSink();
 
 // =======================
+// 4b) RMS audio level monitor
+// =======================
+class RmsMonitorTransform extends stream.Transform {
+  constructor() {
+    super();
+    this.currentRms = 0;
+    this.chunkCount = 0;
+  }
+
+  _transform(chunk, encoding, callback) {
+    this.chunkCount++;
+    // Process every 4th chunk for efficiency (~5-10 readings/sec)
+    if (this.chunkCount % 4 === 0) {
+      const sampleCount = Math.floor(chunk.length / 2);
+      let sumOfSquares = 0;
+      for (let i = 0; i < sampleCount; i++) {
+        const sample = chunk.readInt16LE(i * 2) / 32768;
+        sumOfSquares += sample * sample;
+      }
+      this.currentRms = Math.sqrt(sumOfSquares / sampleCount);
+      this.emit('rms', this.currentRms);
+
+      // Throttled emission to clients (~4Hz)
+      const now = Date.now();
+      if (now - lastRmsEmitTime >= 250) {
+        lastRmsEmitTime = now;
+        io.emit('rmsLevel', { level: this.currentRms });
+      }
+    }
+    callback(null, chunk);
+  }
+}
+
+let rmsMonitor = new RmsMonitorTransform();
+let lastRmsEmitTime = 0;
+
+// =======================
+// 4c) Autoplay state machine
+// =======================
+const AUTOPLAY_DETECT_SUSTAIN_MS = 250;
+const AUTOPLAY_SILENCE_TIMEOUT_MS = 300000; // 5 minutes
+
+let autoplayState = {
+  state: config.autoplayEnabled ? 'idle' : 'paused',
+  detectingSince: null,
+  silenceSince: null,
+};
+
+function emitAutoplayState() {
+  io.emit('autoplay', { state: autoplayState.state });
+}
+
+function activateDefaultOutputs() {
+  if (config.defaultOutputIds.length === 0) return;
+
+  // Ensure default input is selected
+  if (config.defaultInputId && currentInput !== config.defaultInputId) {
+    // Input switching is handled elsewhere; for autoplay we assume it's already set at startup
+  }
+
+  volume = config.defaultVolume || 50;
+  const validOutputIds = config.defaultOutputIds.filter(outputId =>
+    unifiedOutputs.some(output => output.uiId === outputId)
+  );
+  if (validOutputIds.length > 0) {
+    syncOutputs(validOutputIds);
+    io.emit('output', { ids: validOutputIds });
+    io.emit('volume', { value: volume });
+    io.emit('status', { message: 'Autoplay activated' });
+    console.log("Autoplay: activated default outputs:", validOutputIds);
+  }
+}
+
+function deactivateOutputs() {
+  syncOutputs([]);
+  io.emit('output', { ids: [] });
+  io.emit('status', { message: 'Autoplay: speakers released after silence' });
+  console.log("Autoplay: deactivated outputs after silence timeout");
+}
+
+function tickAutoplay(rmsLevel) {
+  const threshold = config.autoplayThreshold || 0.002;
+  const now = Date.now();
+
+  switch (autoplayState.state) {
+    case 'paused':
+      return; // Do nothing
+
+    case 'idle':
+      if (rmsLevel > threshold) {
+        autoplayState.state = 'detecting';
+        autoplayState.detectingSince = now;
+        emitAutoplayState();
+      }
+      break;
+
+    case 'detecting':
+      if (rmsLevel <= threshold) {
+        // Signal dropped — false trigger
+        autoplayState.state = 'idle';
+        autoplayState.detectingSince = null;
+        emitAutoplayState();
+      } else if (now - autoplayState.detectingSince >= AUTOPLAY_DETECT_SUSTAIN_MS) {
+        // Sustained signal — activate!
+        autoplayState.state = 'playing';
+        autoplayState.detectingSince = null;
+        emitAutoplayState();
+        activateDefaultOutputs();
+      }
+      break;
+
+    case 'playing':
+      if (rmsLevel <= threshold) {
+        autoplayState.state = 'silence';
+        autoplayState.silenceSince = now;
+        emitAutoplayState();
+      }
+      break;
+
+    case 'silence':
+      if (rmsLevel > threshold) {
+        // Sound returned
+        autoplayState.state = 'playing';
+        autoplayState.silenceSince = null;
+        emitAutoplayState();
+      } else if (now - autoplayState.silenceSince >= AUTOPLAY_SILENCE_TIMEOUT_MS) {
+        // Extended silence — release speakers
+        autoplayState.state = 'idle';
+        autoplayState.silenceSince = null;
+        emitAutoplayState();
+        deactivateOutputs();
+      }
+      break;
+  }
+}
+
+function setAutoplayState(newState) {
+  if (newState === 'paused') {
+    autoplayState.state = 'paused';
+    autoplayState.detectingSince = null;
+    autoplayState.silenceSince = null;
+    // Master kill switch — stop all outputs
+    syncOutputs([]);
+    io.emit('output', { ids: [] });
+    emitAutoplayState();
+    console.log("Autoplay: paused (all outputs stopped)");
+  } else if (newState === 'playing') {
+    autoplayState.state = 'idle'; // Enter idle, let RMS detection handle the rest
+    autoplayState.detectingSince = null;
+    autoplayState.silenceSince = null;
+    emitAutoplayState();
+    console.log("Autoplay: armed and listening");
+  }
+}
+
+// Hook RMS readings into autoplay state machine
+function wireRmsMonitor() {
+  rmsMonitor.on('rms', tickAutoplay);
+}
+wireRmsMonitor();
+
+// =======================
 // 5) Main audio duplicator
 // =======================
 const duplicator = new stream.PassThrough({ highWaterMark: 65536 });
@@ -91,13 +299,14 @@ function FromVoid() {
 }
 FromVoid.prototype._read = function () { };
 let inputStream = new FromVoid();
-inputStream.pipe(duplicator);
+rmsMonitor.pipe(duplicator);
+inputStream.pipe(rmsMonitor);
 
 // Clean up current input, stop processes
 function cleanupCurrentInput() {
   try {
     if (inputStream) {
-      inputStream.unpipe(duplicator);
+      inputStream.unpipe(rmsMonitor);
       inputStream = null;
     }
     if (arecordInstance) {
@@ -153,7 +362,10 @@ function startArecordForDevice(devId, isRetry = false) {
     inputStream.on('error', (error) => {
       console.error(`Error with input stream for ${devId}:`, error);
     });
-    inputStream.pipe(duplicator);
+    rmsMonitor = new RmsMonitorTransform();
+    wireRmsMonitor();
+    rmsMonitor.pipe(duplicator);
+    inputStream.pipe(rmsMonitor);
 
     if (isRetry) {
       busyRetryAttempts = 0;
@@ -259,7 +471,7 @@ function setupArecordHandlers(devId, isRetry = false) {
 // =======================
 // 7) Volume & outputs
 // =======================
-let volume = 50;
+let volume = config.defaultVolume || 50;
 let selectedOutputs = [];
 
 let availablePcmOutputs = [];
@@ -363,7 +575,9 @@ function buildStatePayload() {
     outputs: buildCleanOutputs(),
     selectedInput: currentInput,
     selectedOutputs,
-    volume
+    volume,
+    config,
+    autoplayState: autoplayState.state
   };
 }
 
@@ -381,9 +595,12 @@ function updateAllInputs() {
 if (!process.env.DISABLE_PCM) {
   console.log("PCM device scanning enabled");
   scanPcmDevices();
-  // Auto-select first available input on startup
+  // Auto-select input on startup: prefer config default, then first available
   if (currentInput === "void" && availablePcmInputs.length > 0) {
-    const autoDevId = availablePcmInputs[0].id;
+    const configuredInput = config.defaultInputId && availablePcmInputs.some(d => d.id === config.defaultInputId)
+      ? config.defaultInputId
+      : availablePcmInputs[0].id;
+    const autoDevId = configuredInput;
     console.log("Auto-selecting input:", autoDevId);
     cleanupCurrentInput();
     currentInput = autoDevId;
@@ -395,7 +612,10 @@ if (!process.env.DISABLE_PCM) {
     inputStream.on('error', (error) => {
       console.error(`Error with auto-selected input stream for ${autoDevId}:`, error);
     });
-    inputStream.pipe(duplicator);
+    rmsMonitor = new RmsMonitorTransform();
+    wireRmsMonitor();
+    rmsMonitor.pipe(duplicator);
+    inputStream.pipe(rmsMonitor);
   }
   setInterval(scanPcmDevices, 10000);
 } else {
@@ -550,20 +770,26 @@ browser.start();
 let advertise = null;
 function advertiseService() {
   try {
-    // use random port if needed, otherwise use 3000
     const p = Number(process.env.BABEL_PORT || 3000);
     advertise = mdns.createAdvertisement(mdns.tcp('babelpod'), p, {
-      name: hostname().replace('.local', ''),
+      name: config.displayName || hostname().replace('.local', ''),
       txt: {
         info: "A BabelPod audio server"
       }
     });
     console.log("Advertising BabelPod service:", advertise);
-
     advertise.start();
   } catch (err) {
     console.log("Error advertising BabelPod service:", err);
   }
+}
+function restartAdvertisement() {
+  try {
+    if (advertise) advertise.stop();
+  } catch (err) {
+    console.error("Error stopping advertisement:", err);
+  }
+  advertiseService();
 }
 advertiseService();
 
@@ -748,7 +974,10 @@ io.on('connection', socket => {
 
       if (devId === "void") {
         inputStream = new FromVoid();
-        inputStream.pipe(duplicator);
+        rmsMonitor = new RmsMonitorTransform();
+        wireRmsMonitor();
+        rmsMonitor.pipe(duplicator);
+        inputStream.pipe(rmsMonitor);
         io.emit('input', { id: currentInput });
         io.emit('status', { message: `Input switched to ${currentInput}` });
         isManualInputSwitch = false;
@@ -826,6 +1055,38 @@ io.on('connection', socket => {
       console.error("Error changing volume:", e);
       io.emit('serverError', { message: `Failed to change volume: ${e.message}` });
     }
+  });
+
+  socket.on('setConfig', (data) => {
+    if (socket.id !== sessionOwner) return;
+    if (!data || typeof data !== 'object') return;
+
+    console.log("Updating config:", data);
+    const oldDisplayName = config.displayName;
+
+    // Only allow known fields
+    const allowedFields = ['displayName', 'defaultInputId', 'defaultOutputIds', 'defaultVolume', 'autoplayEnabled', 'autoplayThreshold'];
+    const filtered = {};
+    for (const key of allowedFields) {
+      if (key in data) filtered[key] = data[key];
+    }
+
+    saveConfig(filtered);
+
+    if (config.displayName !== oldDisplayName) {
+      restartAdvertisement();
+    }
+
+    io.emit('status', { message: 'Settings saved' });
+  });
+
+  socket.on('setAutoplay', (data) => {
+    if (socket.id !== sessionOwner) return;
+    const newState = data?.state;
+    if (newState !== 'playing' && newState !== 'paused') return;
+
+    console.log("Setting autoplay state:", newState);
+    setAutoplayState(newState);
   });
 
   socket.on('disconnect', () => {

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ const DEFAULT_CONFIG = {
   defaultOutputIds: [],
   defaultVolume: 50,
   autoconnectEnabled: false,
-  autoconnectThreshold: 0.005
+  autoconnectThreshold: 0.01
 };
 
 let config = { ...DEFAULT_CONFIG };

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ const DEFAULT_CONFIG = {
   defaultOutputIds: [],
   defaultVolume: 50,
   autoconnectEnabled: false,
-  autoconnectThreshold: 0.002
+  autoconnectThreshold: 0.005
 };
 
 let config = { ...DEFAULT_CONFIG };
@@ -223,18 +223,29 @@ let lastRmsLogTime = 0;
 let maxRmsSinceLastLog = 0;
 const RMS_LOG_INTERVAL_MS = 10000; // every 10 seconds
 
+// Smoothed RMS via exponential moving average — distinguishes sustained
+// music from transient spikes like surface noise pops.
+// alpha=0.15 with ~10 samples/sec ≈ 1s time constant.
+let smoothedRms = 0;
+const RMS_SMOOTHING_ALPHA = 0.15;
+
 function logStateTransition(fromState, toState, rmsLevel, reason) {
   log.info(`[autoconnect] ${fromState} → ${toState} (rms=${rmsLevel.toFixed(4)}, reason=${reason})`);
 }
 
-function tickAutoconnect(rmsLevel) {
+function tickAutoconnect(rawRms) {
   const threshold = config.autoconnectThreshold || 0.002;
   const now = Date.now();
 
+  // Smoothed RMS filters transient spikes (surface noise pops) while
+  // preserving sustained signal detection (music). Used for steady-state
+  // decisions; raw RMS is used for initial detection to catch transients fast.
+  smoothedRms = RMS_SMOOTHING_ALPHA * rawRms + (1 - RMS_SMOOTHING_ALPHA) * smoothedRms;
+
   // Periodic RMS sample logging
-  if (rmsLevel > maxRmsSinceLastLog) maxRmsSinceLastLog = rmsLevel;
+  if (rawRms > maxRmsSinceLastLog) maxRmsSinceLastLog = rawRms;
   if (now - lastRmsLogTime >= RMS_LOG_INTERVAL_MS) {
-    log.debug(`[autoconnect] state=${autoconnectState.state} threshold=${threshold} peak_rms=${maxRmsSinceLastLog.toFixed(4)} current_rms=${rmsLevel.toFixed(4)}`);
+    log.debug(`[autoconnect] state=${autoconnectState.state} threshold=${threshold} peak_raw=${maxRmsSinceLastLog.toFixed(4)} smoothed=${smoothedRms.toFixed(4)}`);
     lastRmsLogTime = now;
     maxRmsSinceLastLog = 0;
   }
@@ -244,8 +255,9 @@ function tickAutoconnect(rmsLevel) {
       return;
 
     case 'idle':
-      if (rmsLevel > threshold) {
-        logStateTransition('idle', 'detecting', rmsLevel, `above threshold ${threshold}`);
+      // Use raw RMS — catch transient signal like needle drop immediately
+      if (rawRms > threshold) {
+        logStateTransition('idle', 'detecting', rawRms, `raw above threshold ${threshold}`);
         autoconnectState.state = 'detecting';
         autoconnectState.detectingSince = now;
         emitAutoconnectState();
@@ -253,14 +265,16 @@ function tickAutoconnect(rmsLevel) {
       break;
 
     case 'detecting':
-      if (rmsLevel <= threshold) {
+      // Use raw RMS for sustain check — filters pops (they don't sustain 250ms)
+      // but still catches sustained lead-in groove noise
+      if (rawRms <= threshold) {
         const heldFor = now - autoconnectState.detectingSince;
-        logStateTransition('detecting', 'idle', rmsLevel, `dropped after ${heldFor}ms (needed ${AUTOCONNECT_DETECT_SUSTAIN_MS}ms)`);
+        logStateTransition('detecting', 'idle', rawRms, `dropped after ${heldFor}ms (needed ${AUTOCONNECT_DETECT_SUSTAIN_MS}ms)`);
         autoconnectState.state = 'idle';
         autoconnectState.detectingSince = null;
         emitAutoconnectState();
       } else if (now - autoconnectState.detectingSince >= AUTOCONNECT_DETECT_SUSTAIN_MS) {
-        logStateTransition('detecting', 'connected', rmsLevel, `sustained ${AUTOCONNECT_DETECT_SUSTAIN_MS}ms`);
+        logStateTransition('detecting', 'connected', rawRms, `sustained ${AUTOCONNECT_DETECT_SUSTAIN_MS}ms`);
         autoconnectState.state = 'connected';
         autoconnectState.detectingSince = null;
         emitAutoconnectState();
@@ -269,10 +283,10 @@ function tickAutoconnect(rmsLevel) {
       break;
 
     case 'connected':
-      // Hysteresis: only leave connected when RMS drops well below start threshold
-      // This prevents rapid flip-flopping during quiet music passages
-      if (rmsLevel <= threshold / 4) {
-        logStateTransition('connected', 'silence', rmsLevel, `below stop threshold ${(threshold/4).toFixed(4)}`);
+      // Use SMOOTHED RMS — don't flip to silence on brief quiet passages
+      // or between-track gaps. Hysteresis: only leave when well below threshold.
+      if (smoothedRms <= threshold / 4) {
+        logStateTransition('connected', 'silence', smoothedRms, `smoothed below stop threshold ${(threshold/4).toFixed(4)}`);
         autoconnectState.state = 'silence';
         autoconnectState.silenceSince = now;
         emitAutoconnectState();
@@ -280,8 +294,10 @@ function tickAutoconnect(rmsLevel) {
       break;
 
     case 'silence':
-      if (rmsLevel > threshold) {
-        logStateTransition('silence', 'connected', rmsLevel, `signal returned`);
+      // Use SMOOTHED RMS — don't flip back to connected on surface noise pops.
+      // Surface noise has brief spikes but low average; music is sustained.
+      if (smoothedRms > threshold) {
+        logStateTransition('silence', 'connected', smoothedRms, `smoothed signal returned`);
         autoconnectState.state = 'connected';
         autoconnectState.silenceSince = null;
         emitAutoconnectState();

--- a/index.js
+++ b/index.js
@@ -112,6 +112,12 @@ class RmsMonitorTransform extends stream.Transform {
   }
 
   _transform(chunk, encoding, callback) {
+    // Skip RMS calculation when autoplay is paused (save CPU)
+    if (autoplayState.state === 'paused') {
+      callback(null, chunk);
+      return;
+    }
+
     this.chunkCount++;
     // Process every 4th chunk for efficiency (~5-10 readings/sec)
     if (this.chunkCount % 4 === 0) {
@@ -155,11 +161,10 @@ function emitAutoplayState() {
 }
 
 function activateDefaultOutputs() {
-  if (config.defaultOutputIds.length === 0) return;
-
-  // Ensure default input is selected
-  if (config.defaultInputId && currentInput !== config.defaultInputId) {
-    // Input switching is handled elsewhere; for autoplay we assume it's already set at startup
+  if (config.defaultOutputIds.length === 0) {
+    io.emit('status', { message: 'Autoplay: no default outputs configured' });
+    console.log("Autoplay: no default outputs configured");
+    return;
   }
 
   volume = config.defaultVolume || 50;
@@ -170,8 +175,15 @@ function activateDefaultOutputs() {
     syncOutputs(validOutputIds);
     io.emit('output', { ids: validOutputIds });
     io.emit('volume', { value: volume });
-    io.emit('status', { message: 'Autoplay activated' });
+    const missing = config.defaultOutputIds.length - validOutputIds.length;
+    const message = missing > 0
+      ? `Autoplay activated (${missing} default output${missing > 1 ? 's' : ''} unavailable)`
+      : 'Autoplay activated';
+    io.emit('status', { message });
     console.log("Autoplay: activated default outputs:", validOutputIds);
+  } else {
+    io.emit('serverError', { message: 'Autoplay: default outputs not available' });
+    console.log("Autoplay: all default outputs unavailable:", config.defaultOutputIds);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -521,7 +521,7 @@ function scanPcmDevices() {
 function buildUnifiedOutputs() {
   let local = availablePcmOutputs.map(o => ({
     uiId: o.id,
-    name: o.name + ' (Output)',
+    name: o.name + ' - Output',
     isStereo: false,
     devices: [{ localId: o.id }]
   }));
@@ -552,14 +552,14 @@ function buildUnifiedOutputs() {
       const d = arr[0];
       air.push({
         uiId: 'air:' + d.name,
-        name: (d.name || d.host) + ' (AirPlay)',
+        name: (d.name || d.host) + ' - AirPlay',
         isStereo: false,
         devices: [{ host: d.host, port: d.port, isStereo: false }]
       });
     } else {
       air.push({
         uiId: 'airpair:' + stereoName,
-        name: stereoName + ' (AirPlay Stereo)',
+        name: stereoName + ' - AirPlay Stereo',
         isStereo: true,
         devices: arr.map(d => ({ host: d.host, port: d.port, isStereo: true }))
       });

--- a/index.js
+++ b/index.js
@@ -187,7 +187,10 @@ setInterval(() => {
   const silentDuration = Date.now() - lastInputDataTime;
   if (silentDuration > INPUT_WATCHDOG_TIMEOUT_MS) {
     log.warn(`[watchdog] No input data for ${Math.round(silentDuration/1000)}s — restarting input ${currentInput}`);
-    inputRestartAttempts = 0; // Reset counter — this is a watchdog recovery, not a rapid failure
+    // Suppress exit handler auto-restart — the watchdog is handling recovery
+    isManualInputSwitch = true;
+    inputRestartAttempts = 0;
+    lastInputDataTime = Date.now(); // Prevent re-firing while restart is in progress
     restartInputDevice(currentInput, 0);
   }
 }, INPUT_WATCHDOG_INTERVAL_MS);
@@ -436,16 +439,22 @@ function cleanupCurrentInput() {
 // Kill any orphaned arecord processes for the specified device
 function killOrphanedArecord(devId) {
   if (devId === "void" || !devId) return;
+  // Get the pid of our current arecord so we don't kill it
+  const currentPid = arecordInstance ? arecordInstance.pid : null;
   try {
     const result = execSync(`pgrep -f "arecord.*${devId}"`, { encoding: 'utf8' }).trim();
     if (result) {
-      console.log(`Found orphaned arecord processes for ${devId}, terminating: ${result}`);
-      execSync(`pkill -9 -f "arecord.*${devId}"`);
+      const pids = result.split('\n').filter(pid => pid && Number(pid) !== currentPid);
+      if (pids.length > 0) {
+        log.info(`Found orphaned arecord processes for ${devId}: ${pids.join(', ')}`);
+        for (const pid of pids) {
+          try { process.kill(Number(pid), 'SIGKILL'); } catch (e) { /* already gone */ }
+        }
+      }
     }
   } catch (e) {
-    // pgrep returns non-zero if no processes found, which is fine
     if (e.status !== 1) {
-      console.error(`Error checking for orphaned arecord processes: ${e.message}`);
+      log.error(`Error checking for orphaned arecord processes: ${e.message}`);
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -136,6 +136,8 @@ class RmsMonitorTransform extends stream.Transform {
   }
 
   _transform(chunk, encoding, callback) {
+    lastInputDataTime = Date.now();
+
     // Skip RMS calculation when autoconnect is paused (save CPU)
     if (autoconnectState.state === 'paused') {
       callback(null, chunk);
@@ -167,6 +169,28 @@ class RmsMonitorTransform extends stream.Transform {
 
 let rmsMonitor = new RmsMonitorTransform();
 let lastRmsEmitTime = 0;
+
+// =======================
+// 4b-ii) Input stream watchdog
+// =======================
+// Detects stalled/dead input streams that don't produce data.
+// arecord can die silently without triggering the 'exit' event,
+// or the stream can break without the process exiting.
+const INPUT_WATCHDOG_INTERVAL_MS = 15000; // check every 15s
+const INPUT_WATCHDOG_TIMEOUT_MS = 30000;  // 30s without data = dead
+let lastInputDataTime = Date.now();
+
+setInterval(() => {
+  if (currentInput === 'void') return;
+  if (!arecordInstance) return;
+
+  const silentDuration = Date.now() - lastInputDataTime;
+  if (silentDuration > INPUT_WATCHDOG_TIMEOUT_MS) {
+    log.warn(`[watchdog] No input data for ${Math.round(silentDuration/1000)}s — restarting input ${currentInput}`);
+    inputRestartAttempts = 0; // Reset counter — this is a watchdog recovery, not a rapid failure
+    restartInputDevice(currentInput, 0);
+  }
+}, INPUT_WATCHDOG_INTERVAL_MS);
 
 // =======================
 // 4c) Autoconnect state machine
@@ -456,10 +480,25 @@ function startArecordForDevice(devId, isRetry = false) {
     io.emit('input', { id: currentInput });
     io.emit('status', { message: `Input ${isRetry ? 'reconnected' : 'switched'} to ${currentInput}` });
     console.log(`Successfully started arecord for device: ${devId}`);
+    startStabilityTimer();
   } catch (e) {
     console.error(`Failed to start arecord for device ${devId}:`, e);
     io.emit('serverError', { message: `Failed to start input: ${e.message}` });
   }
+}
+
+// Reset restart counter after 5 minutes of stable operation
+const INPUT_STABLE_RESET_MS = 300000;
+let inputStableTimer = null;
+
+function startStabilityTimer() {
+  if (inputStableTimer) clearTimeout(inputStableTimer);
+  inputStableTimer = setTimeout(() => {
+    if (inputRestartAttempts > 0) {
+      log.info(`[watchdog] Input stable for 5 minutes — resetting restart counter from ${inputRestartAttempts}`);
+      inputRestartAttempts = 0;
+    }
+  }, INPUT_STABLE_RESET_MS);
 }
 
 // Restart input device (for automatic recovery)

--- a/index.js
+++ b/index.js
@@ -187,6 +187,19 @@ setInterval(() => {
   const silentDuration = Date.now() - lastInputDataTime;
   if (silentDuration > INPUT_WATCHDOG_TIMEOUT_MS) {
     log.warn(`[watchdog] No input data for ${Math.round(silentDuration/1000)}s — restarting input ${currentInput}`);
+
+    // Disconnect outputs first to prevent clicking on speakers during restart
+    if (selectedOutputs.length > 0) {
+      log.info('[watchdog] Disconnecting outputs before input restart');
+      syncOutputs([]);
+      io.emit('output', { ids: [] });
+      if (autoconnectState.state !== 'paused') {
+        autoconnectState.state = 'idle';
+        autoconnectState.silenceSince = null;
+        emitAutoconnectState();
+      }
+    }
+
     // Suppress exit handler auto-restart — the watchdog is handling recovery
     isManualInputSwitch = true;
     inputRestartAttempts = 0;
@@ -480,11 +493,11 @@ function startArecordForDevice(devId, isRetry = false) {
     rmsMonitor.pipe(duplicator);
     inputStream.pipe(rmsMonitor);
 
+    busyRetryAttempts = 0;
     if (isRetry) {
-      busyRetryAttempts = 0;
-      isManualInputSwitch = false;
-    } else {
-      busyRetryAttempts = 0;
+      // Delay resetting the manual switch flag so the old process's
+      // exit handler doesn't trigger a cascading restart
+      setTimeout(() => { isManualInputSwitch = false; }, 1000);
     }
     io.emit('input', { id: currentInput });
     io.emit('status', { message: `Input ${isRetry ? 'reconnected' : 'switched'} to ${currentInput}` });

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const http = require('http');
 const { Server } = require('socket.io');
 const stream = require('stream');
 const util = require('util');
-const { spawn, execSync } = require('child_process');
+const { spawn } = require('child_process');
 const fs = require('fs');
 const mdns = require('mdns-js');
 const dnssd = require('dnssd2');
@@ -200,11 +200,12 @@ setInterval(() => {
       }
     }
 
-    // Suppress exit handler auto-restart — the watchdog is handling recovery
-    isManualInputSwitch = true;
     inputRestartAttempts = 0;
-    lastInputDataTime = Date.now(); // Prevent re-firing while restart is in progress
-    restartInputDevice(currentInput, 0);
+    lastInputDataTime = Date.now();
+    cleanupCurrentInput();
+    setTimeout(() => {
+      startArecordForDevice(currentInput, true);
+    }, CLEANUP_DELAY);
   }
 }, INPUT_WATCHDOG_INTERVAL_MS);
 
@@ -348,7 +349,7 @@ function tickAutoconnect(rawRms) {
         }
       } else if (now - autoconnectState.silenceSince >= AUTOCONNECT_SILENCE_TIMEOUT_MS) {
         const silentFor = now - autoconnectState.silenceSince;
-        logStateTransition('silence', 'idle', rmsLevel, `silent for ${Math.round(silentFor/1000)}s`);
+        logStateTransition('silence', 'idle', smoothedRms, `silent for ${Math.round(silentFor/1000)}s`);
         autoconnectState.state = 'idle';
         autoconnectState.silenceSince = null;
         emitAutoconnectState();
@@ -403,14 +404,11 @@ duplicator.on('error', e => {
 // =======================
 let currentInput = "void";
 let arecordInstance = null;
-let isManualInputSwitch = false; // Track if input switch was intentional
+let inputGeneration = 0;
 let inputRestartAttempts = 0;
-const MAX_INPUT_RESTART_ATTEMPTS = 3;
-const INPUT_RESTART_DELAY = 2000; // 2 seconds
-const CLEANUP_DELAY = 500; // Delay after cleanup before starting new process
-let busyRetryAttempts = 0;
-const MAX_BUSY_RETRY_ATTEMPTS = 5;
-const BUSY_RETRY_BASE_DELAY = 200; // Base delay for busy retry (exponential backoff)
+const MAX_INPUT_RESTART_ATTEMPTS = 5;
+const INPUT_RESTART_DELAY = 2000;
+const CLEANUP_DELAY = 500;
 
 util.inherits(FromVoid, stream.Readable);
 function FromVoid() {
@@ -429,13 +427,17 @@ function cleanupCurrentInput() {
       inputStream.unpipe(rmsMonitor);
       inputStream = null;
     }
+    if (rmsMonitor) {
+      rmsMonitor.unpipe(duplicator);
+      rmsMonitor.removeAllListeners('rms');
+    }
     if (arecordInstance) {
       try {
         arecordInstance.kill('SIGTERM');
         const instance = arecordInstance;
         setTimeout(() => {
           if (instance && !instance.killed) {
-            console.log('arecord did not terminate gracefully, force killing...');
+            log.warn('arecord did not terminate gracefully, force killing...');
             instance.kill('SIGKILL');
           }
         }, 100);
@@ -449,41 +451,19 @@ function cleanupCurrentInput() {
   }
 }
 
-// Kill any orphaned arecord processes for the specified device
-function killOrphanedArecord(devId) {
-  if (devId === "void" || !devId) return;
-  // Get the pid of our current arecord so we don't kill it
-  const currentPid = arecordInstance ? arecordInstance.pid : null;
-  try {
-    const result = execSync(`pgrep -f "arecord.*${devId}"`, { encoding: 'utf8' }).trim();
-    if (result) {
-      const pids = result.split('\n').filter(pid => pid && Number(pid) !== currentPid);
-      if (pids.length > 0) {
-        log.info(`Found orphaned arecord processes for ${devId}: ${pids.join(', ')}`);
-        for (const pid of pids) {
-          try { process.kill(Number(pid), 'SIGKILL'); } catch (e) { /* already gone */ }
-        }
-      }
-    }
-  } catch (e) {
-    if (e.status !== 1) {
-      log.error(`Error checking for orphaned arecord processes: ${e.message}`);
-    }
-  }
-}
-
-// Start arecord for a specific device with orphan cleanup
+// Start arecord for a specific device
 function startArecordForDevice(devId, isRetry = false) {
   if (devId === "void") return;
+
+  const generation = ++inputGeneration;
+
   try {
-    console.log(`Starting arecord for device: ${devId}${isRetry ? ' (retry)' : ''}`);
-    killOrphanedArecord(devId);
+    console.log(`Starting arecord for device: ${devId}${isRetry ? ` (retry ${inputRestartAttempts}/${MAX_INPUT_RESTART_ATTEMPTS})` : ''}`);
 
     arecordInstance = spawn("arecord", [
       "-D", devId, "-c", "2", "-f", "S16_LE", "-r", "44100"
     ]);
 
-    setupArecordHandlers(devId, isRetry);
     inputStream = arecordInstance.stdout;
     inputStream.on('error', (error) => {
       console.error(`Error with input stream for ${devId}:`, error);
@@ -493,84 +473,63 @@ function startArecordForDevice(devId, isRetry = false) {
     rmsMonitor.pipe(duplicator);
     inputStream.pipe(rmsMonitor);
 
-    busyRetryAttempts = 0;
-    if (isRetry) {
-      // Delay resetting the manual switch flag so the old process's
-      // exit handler doesn't trigger a cascading restart
-      setTimeout(() => { isManualInputSwitch = false; }, 1000);
-    }
+    setupArecordHandlers(devId, generation);
+
     io.emit('input', { id: currentInput });
     io.emit('status', { message: `Input ${isRetry ? 'reconnected' : 'switched'} to ${currentInput}` });
     console.log(`Successfully started arecord for device: ${devId}`);
-    startStabilityTimer();
   } catch (e) {
     console.error(`Failed to start arecord for device ${devId}:`, e);
     io.emit('serverError', { message: `Failed to start input: ${e.message}` });
   }
 }
 
-// Reset restart counter after 5 minutes of stable operation
-const INPUT_STABLE_RESET_MS = 300000;
-let inputStableTimer = null;
-
-function startStabilityTimer() {
-  if (inputStableTimer) clearTimeout(inputStableTimer);
-  inputStableTimer = setTimeout(() => {
-    if (inputRestartAttempts > 0) {
-      log.info(`[watchdog] Input stable for 5 minutes — resetting restart counter from ${inputRestartAttempts}`);
-      inputRestartAttempts = 0;
-    }
-  }, INPUT_STABLE_RESET_MS);
-}
-
-// Restart input device (for automatic recovery)
-function restartInputDevice(devId, delayMs = 0) {
+// Unified input restart with exponential backoff and systemd escalation.
+// Generation-checked at every async boundary — becomes a no-op if a new
+// input session has started (manual switch, watchdog, etc.).
+function scheduleInputRestart(devId, generation) {
   if (devId === "void") return;
+  if (generation !== inputGeneration) return;
+
+  inputRestartAttempts++;
+
+  if (inputRestartAttempts > MAX_INPUT_RESTART_ATTEMPTS) {
+    log.error(`Restart attempts exhausted for ${devId} — exiting for systemd restart`);
+    io.emit('serverError', { message: `Input device failed after ${MAX_INPUT_RESTART_ATTEMPTS} attempts. Service will restart.` });
+    process.exit(1);
+  }
+
+  const delay = INPUT_RESTART_DELAY * Math.pow(1.5, inputRestartAttempts - 1);
+  log.info(`Scheduling input restart for ${devId} in ${Math.round(delay)}ms (attempt ${inputRestartAttempts}/${MAX_INPUT_RESTART_ATTEMPTS})`);
 
   setTimeout(() => {
-    console.log(`Attempting to restart input device: ${devId} (attempt ${inputRestartAttempts + 1}/${MAX_INPUT_RESTART_ATTEMPTS})`);
-    try {
-      cleanupCurrentInput();
-      setTimeout(() => {
-        startArecordForDevice(devId, true);
-        inputRestartAttempts++;
-      }, CLEANUP_DELAY);
-    } catch (e) {
-      console.error(`Failed to restart input device ${devId}:`, e);
-      io.emit('serverError', { message: `Failed to reconnect input: ${e.message}` });
-    }
-  }, delayMs);
+    if (generation !== inputGeneration) return;
+    cleanupCurrentInput();
+    setTimeout(() => {
+      if (generation !== inputGeneration) return;
+      startArecordForDevice(devId, true);
+    }, CLEANUP_DELAY);
+  }, delay);
 }
 
-// Setup arecord process event handlers
-function setupArecordHandlers(devId, isRetry = false) {
+// Setup arecord process event handlers — tagged with generation so stale handlers are no-ops
+function setupArecordHandlers(devId, generation) {
   if (!arecordInstance) return;
 
   arecordInstance.on('error', (error) => {
+    if (generation !== inputGeneration) return;
     console.error(`Error with arecord process for ${devId}:`, error);
     io.emit('serverError', { message: `Input device error: ${error.message}` });
   });
 
   arecordInstance.stderr.on('data', (data) => {
+    if (generation !== inputGeneration) return;
     const msg = data.toString();
     console.error(`arecord stderr for ${devId}:`, msg);
 
-    // Handle "Device or resource busy" with retry
     if (msg.includes('Device or resource busy') || msg.includes('audio open error')) {
-      console.log(`Device busy detected for ${devId}, will retry after cleanup`);
-      if (busyRetryAttempts < MAX_BUSY_RETRY_ATTEMPTS) {
-        busyRetryAttempts++;
-        const delay = BUSY_RETRY_BASE_DELAY * Math.pow(2, busyRetryAttempts - 1);
-        console.log(`Busy retry ${busyRetryAttempts}/${MAX_BUSY_RETRY_ATTEMPTS} in ${delay}ms`);
-        cleanupCurrentInput();
-        setTimeout(() => {
-          startArecordForDevice(devId, true);
-        }, delay);
-      } else {
-        console.error(`Max busy retries reached for ${devId}`);
-        io.emit('serverError', { message: `Input device busy after ${MAX_BUSY_RETRY_ATTEMPTS} retries` });
-        busyRetryAttempts = 0;
-      }
+      log.warn(`Device busy for ${devId}, scheduling retry`);
+      scheduleInputRestart(devId, generation);
       return;
     }
 
@@ -578,34 +537,23 @@ function setupArecordHandlers(devId, isRetry = false) {
       io.emit('serverError', { message: `Input error: ${msg.substring(0, 100)}` });
     }
   });
-  
+
   arecordInstance.on('exit', (code, signal) => {
-    console.log(`arecord exited for ${devId} - code: ${code}, signal: ${signal}, manual: ${isManualInputSwitch}`);
-    
-    // Only attempt restart if:
-    // 1. Exit was unexpected (non-zero code or killed by signal)
-    // 2. It wasn't a manual input switch
-    // 3. We haven't exceeded retry attempts
-    // 4. The current input is still this device
-    if (!isManualInputSwitch && currentInput === devId) {
-      if (code !== 0 || signal) {
-        console.error(`arecord exited unexpectedly with code ${code}, signal ${signal} for ${devId}`);
-        io.emit('serverError', { message: `Input device disconnected - attempting to reconnect...` });
-        
-        if (inputRestartAttempts < MAX_INPUT_RESTART_ATTEMPTS) {
-          restartInputDevice(devId, INPUT_RESTART_DELAY);
-        } else {
-          console.error(`Max restart attempts (${MAX_INPUT_RESTART_ATTEMPTS}) reached for ${devId}`);
-          io.emit('serverError', { message: `Input device failed after ${MAX_INPUT_RESTART_ATTEMPTS} reconnection attempts. Please reselect the input.` });
-          inputRestartAttempts = 0; // Reset for next manual selection
-        }
-      }
+    if (generation !== inputGeneration) {
+      log.debug(`Ignoring stale exit handler for ${devId} (generation ${generation}, current ${inputGeneration})`);
+      return;
     }
-    
-    // Reset flag after handling exit
-    if (isManualInputSwitch) {
-      isManualInputSwitch = false;
+    console.log(`arecord exited for ${devId} - code: ${code}, signal: ${signal}`);
+
+    if (currentInput !== devId) return;
+
+    if (code !== 0 || signal) {
+      console.error(`arecord exited unexpectedly with code ${code}, signal ${signal} for ${devId}`);
+      io.emit('serverError', { message: `Input device disconnected - attempting to reconnect...` });
+    } else {
+      log.warn(`arecord exited cleanly (code 0) for ${devId} — restarting`);
     }
+    scheduleInputRestart(devId, generation);
   });
 }
 
@@ -741,22 +689,10 @@ if (!process.env.DISABLE_PCM) {
     const configuredInput = config.defaultInputId && availablePcmInputs.some(d => d.id === config.defaultInputId)
       ? config.defaultInputId
       : availablePcmInputs[0].id;
-    const autoDevId = configuredInput;
-    console.log("Auto-selecting input:", autoDevId);
+    console.log("Auto-selecting input:", configuredInput);
     cleanupCurrentInput();
-    currentInput = autoDevId;
-    arecordInstance = spawn("arecord", [
-      "-D", autoDevId, "-c", "2", "-f", "S16_LE", "-r", "44100"
-    ]);
-    setupArecordHandlers(autoDevId);
-    inputStream = arecordInstance.stdout;
-    inputStream.on('error', (error) => {
-      console.error(`Error with auto-selected input stream for ${autoDevId}:`, error);
-    });
-    rmsMonitor = new RmsMonitorTransform();
-    wireRmsMonitor();
-    rmsMonitor.pipe(duplicator);
-    inputStream.pipe(rmsMonitor);
+    currentInput = configuredInput;
+    startArecordForDevice(configuredInput, false);
   }
   setInterval(scanPcmDevices, 10000);
 } else {
@@ -1103,17 +1039,14 @@ io.on('connection', socket => {
     console.log("Switching input to:", devId);
 
     if (socket.id !== sessionOwner) return;
-    
-    try {
-      // Mark this as a manual switch to prevent auto-restart
-      isManualInputSwitch = true;
-      inputRestartAttempts = 0;
-      busyRetryAttempts = 0;
 
+    try {
+      inputRestartAttempts = 0;
       cleanupCurrentInput();
       currentInput = devId;
 
       if (devId === "void") {
+        inputGeneration++;
         inputStream = new FromVoid();
         rmsMonitor = new RmsMonitorTransform();
         wireRmsMonitor();
@@ -1121,7 +1054,6 @@ io.on('connection', socket => {
         inputStream.pipe(rmsMonitor);
         io.emit('input', { id: currentInput });
         io.emit('status', { message: `Input switched to ${currentInput}` });
-        isManualInputSwitch = false;
       } else if (devId.includes('bluealsa') && blue) {
         const btDevice = availableBluetoothInputs.find(d => d.id === devId);
         if (btDevice && !btDevice.connected) {
@@ -1140,7 +1072,6 @@ io.on('connection', socket => {
           } catch (e) {
             console.error("Error connecting to Bluetooth device:", e);
             io.emit('serverError', { message: `Failed to connect to Bluetooth: ${e.message}` });
-            isManualInputSwitch = false;
           }
         } else {
           setTimeout(() => {
@@ -1152,7 +1083,7 @@ io.on('connection', socket => {
           startArecordForDevice(devId, false);
         }, CLEANUP_DELAY);
       }
-      
+
     } catch (e) {
       console.error("Error switching input:", e);
       io.emit('serverError', { message: `Failed to switch input: ${e.message}` });
@@ -1260,8 +1191,10 @@ server.listen(PORT, () => {
 // =======================
 process.on('uncaughtException', (error) => {
   console.error('Uncaught Exception:', error);
-  io.emit('serverError', { message: 'Server encountered an unexpected error' });
-  // Don't exit - try to recover
+  try {
+    io.emit('serverError', { message: 'Server encountered an unexpected error — restarting' });
+  } catch (e) { /* socket may be dead */ }
+  process.exit(1);
 });
 
 process.on('unhandledRejection', (reason, promise) => {

--- a/index.js
+++ b/index.js
@@ -40,7 +40,12 @@ function loadConfig() {
   try {
     const data = fs.readFileSync(CONFIG_PATH, 'utf8');
     const parsed = JSON.parse(data);
-    config = { ...DEFAULT_CONFIG, ...parsed };
+    // Only keep known fields; drop legacy keys
+    const clean = {};
+    for (const key of Object.keys(DEFAULT_CONFIG)) {
+      if (key in parsed) clean[key] = parsed[key];
+    }
+    config = { ...DEFAULT_CONFIG, ...clean };
     console.log("Loaded config:", config);
   } catch (error) {
     if (error.code === 'ENOENT') {
@@ -53,7 +58,12 @@ function loadConfig() {
 }
 
 function saveConfig(partial) {
-  config = { ...config, ...partial };
+  // Only merge known fields to avoid polluting config with legacy keys
+  const clean = {};
+  for (const key of Object.keys(DEFAULT_CONFIG)) {
+    if (key in partial) clean[key] = partial[key];
+  }
+  config = { ...config, ...clean };
   try {
     fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
     console.log("Config saved:", config);
@@ -194,16 +204,34 @@ function deactivateOutputs() {
   console.log("Autoconnect: deactivated outputs after silence timeout");
 }
 
+// Periodic RMS logging — helps diagnose missed triggers
+let lastRmsLogTime = 0;
+let maxRmsSinceLastLog = 0;
+const RMS_LOG_INTERVAL_MS = 10000; // every 10 seconds
+
+function logStateTransition(fromState, toState, rmsLevel, reason) {
+  console.log(`[autoconnect] ${fromState} → ${toState} (rms=${rmsLevel.toFixed(4)}, reason=${reason})`);
+}
+
 function tickAutoconnect(rmsLevel) {
   const threshold = config.autoconnectThreshold || 0.002;
   const now = Date.now();
 
+  // Periodic RMS sample logging
+  if (rmsLevel > maxRmsSinceLastLog) maxRmsSinceLastLog = rmsLevel;
+  if (now - lastRmsLogTime >= RMS_LOG_INTERVAL_MS) {
+    console.log(`[autoconnect] state=${autoconnectState.state} threshold=${threshold} peak_rms=${maxRmsSinceLastLog.toFixed(4)} current_rms=${rmsLevel.toFixed(4)}`);
+    lastRmsLogTime = now;
+    maxRmsSinceLastLog = 0;
+  }
+
   switch (autoconnectState.state) {
     case 'paused':
-      return; // Do nothing
+      return;
 
     case 'idle':
       if (rmsLevel > threshold) {
+        logStateTransition('idle', 'detecting', rmsLevel, `above threshold ${threshold}`);
         autoconnectState.state = 'detecting';
         autoconnectState.detectingSince = now;
         emitAutoconnectState();
@@ -212,12 +240,13 @@ function tickAutoconnect(rmsLevel) {
 
     case 'detecting':
       if (rmsLevel <= threshold) {
-        // Signal dropped — false trigger
+        const heldFor = now - autoconnectState.detectingSince;
+        logStateTransition('detecting', 'idle', rmsLevel, `dropped after ${heldFor}ms (needed ${AUTOCONNECT_DETECT_SUSTAIN_MS}ms)`);
         autoconnectState.state = 'idle';
         autoconnectState.detectingSince = null;
         emitAutoconnectState();
       } else if (now - autoconnectState.detectingSince >= AUTOCONNECT_DETECT_SUSTAIN_MS) {
-        // Sustained signal — activate!
+        logStateTransition('detecting', 'connected', rmsLevel, `sustained ${AUTOCONNECT_DETECT_SUSTAIN_MS}ms`);
         autoconnectState.state = 'connected';
         autoconnectState.detectingSince = null;
         emitAutoconnectState();
@@ -227,6 +256,7 @@ function tickAutoconnect(rmsLevel) {
 
     case 'connected':
       if (rmsLevel <= threshold) {
+        logStateTransition('connected', 'silence', rmsLevel, `below threshold`);
         autoconnectState.state = 'silence';
         autoconnectState.silenceSince = now;
         emitAutoconnectState();
@@ -235,12 +265,13 @@ function tickAutoconnect(rmsLevel) {
 
     case 'silence':
       if (rmsLevel > threshold) {
-        // Sound returned
+        logStateTransition('silence', 'connected', rmsLevel, `signal returned`);
         autoconnectState.state = 'connected';
         autoconnectState.silenceSince = null;
         emitAutoconnectState();
       } else if (now - autoconnectState.silenceSince >= AUTOCONNECT_SILENCE_TIMEOUT_MS) {
-        // Extended silence — release speakers
+        const silentFor = now - autoconnectState.silenceSince;
+        logStateTransition('silence', 'idle', rmsLevel, `silent for ${Math.round(silentFor/1000)}s`);
         autoconnectState.state = 'idle';
         autoconnectState.silenceSince = null;
         emitAutoconnectState();

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const http = require('http');
 const { Server } = require('socket.io');
 const stream = require('stream');
 const util = require('util');
-const { spawn } = require('child_process');
+const { spawn, execSync } = require('child_process');
 const fs = require('fs');
 const mdns = require('mdns-js');
 const dnssd = require('dnssd2');
@@ -489,6 +489,45 @@ function startArecordForDevice(devId, isRetry = false) {
   }
 }
 
+function resetUsbAudioDevice() {
+  try {
+    const devicePath = execSync('readlink -f /sys/class/sound/card0/device', { encoding: 'utf8' }).trim();
+    const usbDevice = devicePath.split('/').find(segment => /^\d+-\d+$/.test(segment));
+    if (!usbDevice) {
+      log.error('[recovery] Could not determine USB device ID from path:', devicePath);
+      return false;
+    }
+    log.warn(`[recovery] Resetting USB device ${usbDevice}`);
+    execSync(`echo "${usbDevice}" | sudo /usr/bin/tee /sys/bus/usb/drivers/usb/unbind`, { encoding: 'utf8' });
+    return true;
+  } catch (error) {
+    log.error(`[recovery] USB unbind failed: ${error.message}`);
+    return false;
+  }
+}
+
+function rebindUsbAudioDevice() {
+  try {
+    const devicePath = execSync('readlink -f /sys/class/sound/card0/device', { encoding: 'utf8', timeout: 2000 }).trim();
+    const usbDevice = devicePath.split('/').find(segment => /^\d+-\d+$/.test(segment));
+    if (usbDevice) {
+      execSync(`echo "${usbDevice}" | sudo /usr/bin/tee /sys/bus/usb/drivers/usb/bind`, { encoding: 'utf8' });
+      log.info(`[recovery] USB device ${usbDevice} re-bound`);
+      return;
+    }
+  } catch (_) { /* card0 may not exist yet after unbind */ }
+
+  try {
+    execSync('echo "1-1" | sudo /usr/bin/tee /sys/bus/usb/drivers/usb/bind', { encoding: 'utf8' });
+    log.info('[recovery] USB device 1-1 re-bound (fallback)');
+  } catch (error) {
+    log.error(`[recovery] USB rebind failed: ${error.message}`);
+  }
+}
+
+const USB_RESET_ATTEMPT = 3;
+const USB_REBIND_DELAY = 2000;
+
 // Unified input restart with exponential backoff and systemd escalation.
 // Generation-checked at every async boundary — becomes a no-op if a new
 // input session has started (manual switch, watchdog, etc.).
@@ -502,6 +541,23 @@ function scheduleInputRestart(devId, generation) {
     log.error(`Restart attempts exhausted for ${devId} — exiting for systemd restart`);
     io.emit('serverError', { message: `Input device failed after ${MAX_INPUT_RESTART_ATTEMPTS} attempts. Service will restart.` });
     process.exit(1);
+  }
+
+  if (inputRestartAttempts === USB_RESET_ATTEMPT) {
+    log.warn('[recovery] Attempting USB device reset before retry');
+    cleanupCurrentInput();
+    const unbound = resetUsbAudioDevice();
+    if (unbound) {
+      setTimeout(() => {
+        if (generation !== inputGeneration) return;
+        rebindUsbAudioDevice();
+        setTimeout(() => {
+          if (generation !== inputGeneration) return;
+          startArecordForDevice(devId, true);
+        }, CLEANUP_DELAY);
+      }, USB_REBIND_DELAY);
+      return;
+    }
   }
 
   const delay = INPUT_RESTART_DELAY * Math.pow(1.5, inputRestartAttempts - 1);

--- a/index.js
+++ b/index.js
@@ -446,7 +446,7 @@ function startArecordForDevice(devId, isRetry = false) {
     console.log(`Starting arecord for device: ${devId}${isRetry ? ' (retry)' : ''}`);
 
     arecordInstance = spawn("arecord", [
-      "-D", devId, "-c", "2", "-f", "S16_LE", "-r", "44100", "--buffer-size=131072"
+      "-D", devId, "-t", "raw", "-c", "2", "-f", "S16_LE", "-r", "44100", "--buffer-size=131072"
     ]);
 
     inputStream = arecordInstance.stdout;

--- a/index.js
+++ b/index.js
@@ -601,8 +601,7 @@ function setupArecordHandlers(devId, generation) {
     console.error(`arecord stderr for ${devId}:`, msg);
 
     if (msg.includes('Device or resource busy') || msg.includes('audio open error')) {
-      log.warn(`Device busy for ${devId}, scheduling retry`);
-      scheduleInputRestart(devId, generation);
+      log.warn(`Device busy for ${devId} — exit handler will schedule retry`);
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const http = require('http');
 const { Server } = require('socket.io');
 const stream = require('stream');
 const util = require('util');
-const { spawn, execSync, exec } = require('child_process');
+const { spawn } = require('child_process');
 const fs = require('fs');
 const mdns = require('mdns-js');
 const dnssd = require('dnssd2');
@@ -186,26 +186,9 @@ setInterval(() => {
 
   const silentDuration = Date.now() - lastInputDataTime;
   if (silentDuration > INPUT_WATCHDOG_TIMEOUT_MS) {
-    log.warn(`[watchdog] No input data for ${Math.round(silentDuration/1000)}s — restarting input ${currentInput}`);
-
-    // Disconnect outputs first to prevent clicking on speakers during restart
-    if (selectedOutputs.length > 0) {
-      log.info('[watchdog] Disconnecting outputs before input restart');
-      syncOutputs([]);
-      io.emit('output', { ids: [] });
-      if (autoconnectState.state !== 'paused') {
-        autoconnectState.state = 'idle';
-        autoconnectState.silenceSince = null;
-        emitAutoconnectState();
-      }
-    }
-
-    inputRestartAttempts = 0;
-    lastInputDataTime = Date.now();
-    cleanupCurrentInput();
-    setTimeout(() => {
-      startArecordForDevice(currentInput, true);
-    }, CLEANUP_DELAY);
+    log.error(`[watchdog] No input data for ${Math.round(silentDuration/1000)}s — exiting for systemd restart`);
+    io.emit('serverError', { message: 'Input device stalled — service will restart' });
+    process.exit(1);
   }
 }, INPUT_WATCHDOG_INTERVAL_MS);
 
@@ -410,9 +393,6 @@ duplicator.on('error', e => {
 let currentInput = "void";
 let arecordInstance = null;
 let inputGeneration = 0;
-let inputRestartAttempts = 0;
-const MAX_INPUT_RESTART_ATTEMPTS = 3;
-const INPUT_RESTART_DELAY = 1000;
 const CLEANUP_DELAY = 500;
 
 util.inherits(FromVoid, stream.Readable);
@@ -463,7 +443,7 @@ function startArecordForDevice(devId, isRetry = false) {
   const generation = ++inputGeneration;
 
   try {
-    console.log(`Starting arecord for device: ${devId}${isRetry ? ` (retry ${inputRestartAttempts}/${MAX_INPUT_RESTART_ATTEMPTS})` : ''}`);
+    console.log(`Starting arecord for device: ${devId}${isRetry ? ' (retry)' : ''}`);
 
     arecordInstance = spawn("arecord", [
       "-D", devId, "-c", "2", "-f", "S16_LE", "-r", "44100", "--buffer-size=131072"
@@ -489,100 +469,10 @@ function startArecordForDevice(devId, isRetry = false) {
   }
 }
 
-function getUsbDeviceId(callback) {
-  exec('readlink -f /sys/class/sound/card0/device', { encoding: 'utf8', timeout: 2000 }, (error, stdout) => {
-    if (error) {
-      callback(null);
-      return;
-    }
-    const usbDevice = stdout.trim().split('/').find(segment => /^\d+-\d+$/.test(segment));
-    callback(usbDevice || null);
-  });
-}
-
-function resetUsbAudioDevice(callback) {
-  getUsbDeviceId((usbDevice) => {
-    if (!usbDevice) {
-      log.error('[recovery] Could not determine USB device ID');
-      callback(false);
-      return;
-    }
-    log.warn(`[recovery] Unbinding USB device ${usbDevice}`);
-    exec(`echo "${usbDevice}" | sudo /usr/bin/tee /sys/bus/usb/drivers/usb/unbind`, { encoding: 'utf8', timeout: 5000 }, (error) => {
-      if (error) {
-        log.error(`[recovery] USB unbind failed: ${error.message}`);
-        callback(false);
-        return;
-      }
-      callback(true, usbDevice);
-    });
-  });
-}
-
-function rebindUsbAudioDevice(unboundDevice, callback) {
-  const deviceId = unboundDevice || '1-1';
-  log.info(`[recovery] Rebinding USB device ${deviceId}`);
-  exec(`echo "${deviceId}" | sudo /usr/bin/tee /sys/bus/usb/drivers/usb/bind`, { encoding: 'utf8', timeout: 5000 }, (error) => {
-    if (error) {
-      log.error(`[recovery] USB rebind failed: ${error.message}`);
-    } else {
-      log.info(`[recovery] USB device ${deviceId} re-bound`);
-    }
-    callback();
-  });
-}
-
-const USB_RESET_ATTEMPT = 3;
-const USB_REBIND_DELAY = 2000;
-
-// Unified input restart with fixed delay and USB reset on final attempt.
-// Generation-checked at every async boundary — becomes a no-op if a new
-// input session has started (manual switch, watchdog, etc.).
-function scheduleInputRestart(devId, generation) {
-  if (devId === "void") return;
-  if (generation !== inputGeneration) return;
-
-  inputRestartAttempts++;
-
-  if (inputRestartAttempts > MAX_INPUT_RESTART_ATTEMPTS) {
-    log.error(`Restart attempts exhausted for ${devId} — exiting for systemd restart`);
-    io.emit('serverError', { message: `Input device failed after ${MAX_INPUT_RESTART_ATTEMPTS} attempts. Service will restart.` });
-    process.exit(1);
-  }
-
-  if (inputRestartAttempts === USB_RESET_ATTEMPT) {
-    log.warn('[recovery] Attempting USB device reset before retry');
-    cleanupCurrentInput();
-    resetUsbAudioDevice((unbound, usbDevice) => {
-      if (generation !== inputGeneration) return;
-      if (unbound) {
-        setTimeout(() => {
-          if (generation !== inputGeneration) return;
-          rebindUsbAudioDevice(usbDevice, () => {
-            if (generation !== inputGeneration) return;
-            setTimeout(() => {
-              if (generation !== inputGeneration) return;
-              startArecordForDevice(devId, true);
-            }, CLEANUP_DELAY);
-          });
-        }, USB_REBIND_DELAY);
-      } else {
-        startArecordForDevice(devId, true);
-      }
-    });
-    return;
-  }
-
-  log.info(`Scheduling input restart for ${devId} in ${INPUT_RESTART_DELAY}ms (attempt ${inputRestartAttempts}/${MAX_INPUT_RESTART_ATTEMPTS})`);
-
-  setTimeout(() => {
-    if (generation !== inputGeneration) return;
-    cleanupCurrentInput();
-    setTimeout(() => {
-      if (generation !== inputGeneration) return;
-      startArecordForDevice(devId, true);
-    }, CLEANUP_DELAY);
-  }, INPUT_RESTART_DELAY);
+function exitForRestart(devId, reason) {
+  log.error(`arecord failed for ${devId} (${reason}) — exiting for systemd restart`);
+  io.emit('serverError', { message: `Input device failed — service will restart` });
+  process.exit(1);
 }
 
 // Setup arecord process event handlers — tagged with generation so stale handlers are no-ops
@@ -619,13 +509,7 @@ function setupArecordHandlers(devId, generation) {
 
     if (currentInput !== devId) return;
 
-    if (code !== 0 || signal) {
-      console.error(`arecord exited unexpectedly with code ${code}, signal ${signal} for ${devId}`);
-      io.emit('serverError', { message: `Input device disconnected - attempting to reconnect...` });
-    } else {
-      log.warn(`arecord exited cleanly (code 0) for ${devId} — restarting`);
-    }
-    scheduleInputRestart(devId, generation);
+    exitForRestart(devId, `code=${code} signal=${signal}`);
   });
 }
 
@@ -1113,7 +997,6 @@ io.on('connection', socket => {
     if (socket.id !== sessionOwner) return;
 
     try {
-      inputRestartAttempts = 0;
       cleanupCurrentInput();
       currentInput = devId;
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const http = require('http');
 const { Server } = require('socket.io');
 const stream = require('stream');
 const util = require('util');
-const { spawn, execSync } = require('child_process');
+const { spawn, execSync, exec } = require('child_process');
 const fs = require('fs');
 const mdns = require('mdns-js');
 const dnssd = require('dnssd2');
@@ -411,8 +411,8 @@ let currentInput = "void";
 let arecordInstance = null;
 let inputGeneration = 0;
 let inputRestartAttempts = 0;
-const MAX_INPUT_RESTART_ATTEMPTS = 5;
-const INPUT_RESTART_DELAY = 2000;
+const MAX_INPUT_RESTART_ATTEMPTS = 3;
+const INPUT_RESTART_DELAY = 1000;
 const CLEANUP_DELAY = 500;
 
 util.inherits(FromVoid, stream.Readable);
@@ -489,46 +489,53 @@ function startArecordForDevice(devId, isRetry = false) {
   }
 }
 
-function resetUsbAudioDevice() {
-  try {
-    const devicePath = execSync('readlink -f /sys/class/sound/card0/device', { encoding: 'utf8' }).trim();
-    const usbDevice = devicePath.split('/').find(segment => /^\d+-\d+$/.test(segment));
-    if (!usbDevice) {
-      log.error('[recovery] Could not determine USB device ID from path:', devicePath);
-      return false;
-    }
-    log.warn(`[recovery] Resetting USB device ${usbDevice}`);
-    execSync(`echo "${usbDevice}" | sudo /usr/bin/tee /sys/bus/usb/drivers/usb/unbind`, { encoding: 'utf8' });
-    return true;
-  } catch (error) {
-    log.error(`[recovery] USB unbind failed: ${error.message}`);
-    return false;
-  }
-}
-
-function rebindUsbAudioDevice() {
-  try {
-    const devicePath = execSync('readlink -f /sys/class/sound/card0/device', { encoding: 'utf8', timeout: 2000 }).trim();
-    const usbDevice = devicePath.split('/').find(segment => /^\d+-\d+$/.test(segment));
-    if (usbDevice) {
-      execSync(`echo "${usbDevice}" | sudo /usr/bin/tee /sys/bus/usb/drivers/usb/bind`, { encoding: 'utf8' });
-      log.info(`[recovery] USB device ${usbDevice} re-bound`);
+function getUsbDeviceId(callback) {
+  exec('readlink -f /sys/class/sound/card0/device', { encoding: 'utf8', timeout: 2000 }, (error, stdout) => {
+    if (error) {
+      callback(null);
       return;
     }
-  } catch (_) { /* card0 may not exist yet after unbind */ }
+    const usbDevice = stdout.trim().split('/').find(segment => /^\d+-\d+$/.test(segment));
+    callback(usbDevice || null);
+  });
+}
 
-  try {
-    execSync('echo "1-1" | sudo /usr/bin/tee /sys/bus/usb/drivers/usb/bind', { encoding: 'utf8' });
-    log.info('[recovery] USB device 1-1 re-bound (fallback)');
-  } catch (error) {
-    log.error(`[recovery] USB rebind failed: ${error.message}`);
-  }
+function resetUsbAudioDevice(callback) {
+  getUsbDeviceId((usbDevice) => {
+    if (!usbDevice) {
+      log.error('[recovery] Could not determine USB device ID');
+      callback(false);
+      return;
+    }
+    log.warn(`[recovery] Unbinding USB device ${usbDevice}`);
+    exec(`echo "${usbDevice}" | sudo /usr/bin/tee /sys/bus/usb/drivers/usb/unbind`, { encoding: 'utf8', timeout: 5000 }, (error) => {
+      if (error) {
+        log.error(`[recovery] USB unbind failed: ${error.message}`);
+        callback(false);
+        return;
+      }
+      callback(true, usbDevice);
+    });
+  });
+}
+
+function rebindUsbAudioDevice(unboundDevice, callback) {
+  const deviceId = unboundDevice || '1-1';
+  log.info(`[recovery] Rebinding USB device ${deviceId}`);
+  exec(`echo "${deviceId}" | sudo /usr/bin/tee /sys/bus/usb/drivers/usb/bind`, { encoding: 'utf8', timeout: 5000 }, (error) => {
+    if (error) {
+      log.error(`[recovery] USB rebind failed: ${error.message}`);
+    } else {
+      log.info(`[recovery] USB device ${deviceId} re-bound`);
+    }
+    callback();
+  });
 }
 
 const USB_RESET_ATTEMPT = 3;
 const USB_REBIND_DELAY = 2000;
 
-// Unified input restart with exponential backoff and systemd escalation.
+// Unified input restart with fixed delay and USB reset on final attempt.
 // Generation-checked at every async boundary — becomes a no-op if a new
 // input session has started (manual switch, watchdog, etc.).
 function scheduleInputRestart(devId, generation) {
@@ -546,22 +553,27 @@ function scheduleInputRestart(devId, generation) {
   if (inputRestartAttempts === USB_RESET_ATTEMPT) {
     log.warn('[recovery] Attempting USB device reset before retry');
     cleanupCurrentInput();
-    const unbound = resetUsbAudioDevice();
-    if (unbound) {
-      setTimeout(() => {
-        if (generation !== inputGeneration) return;
-        rebindUsbAudioDevice();
+    resetUsbAudioDevice((unbound, usbDevice) => {
+      if (generation !== inputGeneration) return;
+      if (unbound) {
         setTimeout(() => {
           if (generation !== inputGeneration) return;
-          startArecordForDevice(devId, true);
-        }, CLEANUP_DELAY);
-      }, USB_REBIND_DELAY);
-      return;
-    }
+          rebindUsbAudioDevice(usbDevice, () => {
+            if (generation !== inputGeneration) return;
+            setTimeout(() => {
+              if (generation !== inputGeneration) return;
+              startArecordForDevice(devId, true);
+            }, CLEANUP_DELAY);
+          });
+        }, USB_REBIND_DELAY);
+      } else {
+        startArecordForDevice(devId, true);
+      }
+    });
+    return;
   }
 
-  const delay = INPUT_RESTART_DELAY * Math.pow(1.5, inputRestartAttempts - 1);
-  log.info(`Scheduling input restart for ${devId} in ${Math.round(delay)}ms (attempt ${inputRestartAttempts}/${MAX_INPUT_RESTART_ATTEMPTS})`);
+  log.info(`Scheduling input restart for ${devId} in ${INPUT_RESTART_DELAY}ms (attempt ${inputRestartAttempts}/${MAX_INPUT_RESTART_ATTEMPTS})`);
 
   setTimeout(() => {
     if (generation !== inputGeneration) return;
@@ -570,7 +582,7 @@ function scheduleInputRestart(devId, generation) {
       if (generation !== inputGeneration) return;
       startArecordForDevice(devId, true);
     }, CLEANUP_DELAY);
-  }, delay);
+  }, INPUT_RESTART_DELAY);
 }
 
 // Setup arecord process event handlers — tagged with generation so stale handlers are no-ops

--- a/index.js
+++ b/index.js
@@ -264,6 +264,11 @@ let lastRmsLogTime = 0;
 let maxRmsSinceLastLog = 0;
 const RMS_LOG_INTERVAL_MS = 10000; // every 10 seconds
 
+setInterval(() => {
+  const mem = process.memoryUsage();
+  log.debug(`[memory] rss=${Math.round(mem.rss / 1024 / 1024)}MB heap=${Math.round(mem.heapUsed / 1024 / 1024)}/${Math.round(mem.heapTotal / 1024 / 1024)}MB external=${Math.round(mem.external / 1024 / 1024)}MB`);
+}, 300000);
+
 // Smoothed RMS via exponential moving average — distinguishes sustained
 // music from transient spikes like surface noise pops.
 // alpha=0.15 with ~10 samples/sec ≈ 1s time constant.
@@ -440,7 +445,7 @@ function cleanupCurrentInput() {
             log.warn('arecord did not terminate gracefully, force killing...');
             instance.kill('SIGKILL');
           }
-        }, 100);
+        }, 2000);
       } catch (e) {
         console.error("Error killing arecord instance:", e);
       }
@@ -461,7 +466,7 @@ function startArecordForDevice(devId, isRetry = false) {
     console.log(`Starting arecord for device: ${devId}${isRetry ? ` (retry ${inputRestartAttempts}/${MAX_INPUT_RESTART_ATTEMPTS})` : ''}`);
 
     arecordInstance = spawn("arecord", [
-      "-D", devId, "-c", "2", "-f", "S16_LE", "-r", "44100"
+      "-D", devId, "-c", "2", "-f", "S16_LE", "-r", "44100", "--buffer-size=131072"
     ]);
 
     inputStream = arecordInstance.stdout;

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -119,11 +119,226 @@ describe('BabelPod Utility Functions', () => {
 
   describe('AirPlay Pipe Stability', () => {
     test('should use end:false option for AirPlay pipe', () => {
-      // The pipe to airtunes should use {end: false} for stability
-      // This prevents the stream from being ended when input changes
       const pipeOptions = { end: false };
       expect(pipeOptions.end).toBe(false);
     });
+  });
+});
+
+describe('RMS Audio Level Calculation', () => {
+  function calculateRms(buffer) {
+    const sampleCount = Math.floor(buffer.length / 2);
+    let sumOfSquares = 0;
+    for (let i = 0; i < sampleCount; i++) {
+      const sample = buffer.readInt16LE(i * 2) / 32768;
+      sumOfSquares += sample * sample;
+    }
+    return Math.sqrt(sumOfSquares / sampleCount);
+  }
+
+  test('should return 0 for silent audio (all zeros)', () => {
+    const buffer = Buffer.alloc(4096, 0);
+    expect(calculateRms(buffer)).toBe(0);
+  });
+
+  test('should return near 1.0 for maximum amplitude', () => {
+    const buffer = Buffer.alloc(4096);
+    for (let i = 0; i < buffer.length / 2; i++) {
+      buffer.writeInt16LE(32767, i * 2);
+    }
+    const rms = calculateRms(buffer);
+    expect(rms).toBeGreaterThan(0.99);
+    expect(rms).toBeLessThanOrEqual(1.0);
+  });
+
+  test('should return intermediate value for half amplitude', () => {
+    const buffer = Buffer.alloc(4096);
+    for (let i = 0; i < buffer.length / 2; i++) {
+      buffer.writeInt16LE(16384, i * 2);
+    }
+    const rms = calculateRms(buffer);
+    expect(rms).toBeGreaterThan(0.4);
+    expect(rms).toBeLessThan(0.6);
+  });
+
+  test('should handle typical noise floor levels', () => {
+    const buffer = Buffer.alloc(4096);
+    for (let i = 0; i < buffer.length / 2; i++) {
+      buffer.writeInt16LE(Math.round(Math.random() * 60 - 30), i * 2);
+    }
+    const rms = calculateRms(buffer);
+    expect(rms).toBeGreaterThan(0);
+    expect(rms).toBeLessThan(0.002);
+  });
+});
+
+describe('Autoplay State Machine', () => {
+  const DETECT_SUSTAIN_MS = 250;
+  const SILENCE_TIMEOUT_MS = 300000;
+
+  let autoplayState;
+
+  function createState(initialState = 'idle') {
+    return {
+      state: initialState,
+      detectingSince: null,
+      silenceSince: null,
+    };
+  }
+
+  function tickAutoplay(state, rmsLevel, threshold = 0.002, now = Date.now()) {
+    switch (state.state) {
+      case 'paused':
+        return state;
+      case 'idle':
+        if (rmsLevel > threshold) {
+          return { ...state, state: 'detecting', detectingSince: now };
+        }
+        return state;
+      case 'detecting':
+        if (rmsLevel <= threshold) {
+          return { ...state, state: 'idle', detectingSince: null };
+        } else if (now - state.detectingSince >= DETECT_SUSTAIN_MS) {
+          return { ...state, state: 'playing', detectingSince: null };
+        }
+        return state;
+      case 'playing':
+        if (rmsLevel <= threshold) {
+          return { ...state, state: 'silence', silenceSince: now };
+        }
+        return state;
+      case 'silence':
+        if (rmsLevel > threshold) {
+          return { ...state, state: 'playing', silenceSince: null };
+        } else if (now - state.silenceSince >= SILENCE_TIMEOUT_MS) {
+          return { ...state, state: 'idle', silenceSince: null };
+        }
+        return state;
+      default:
+        return state;
+    }
+  }
+
+  test('should stay paused when receiving audio', () => {
+    const state = createState('paused');
+    const result = tickAutoplay(state, 0.1);
+    expect(result.state).toBe('paused');
+  });
+
+  test('should transition from idle to detecting on signal', () => {
+    const state = createState('idle');
+    const result = tickAutoplay(state, 0.01);
+    expect(result.state).toBe('detecting');
+    expect(result.detectingSince).not.toBeNull();
+  });
+
+  test('should stay idle when signal is below threshold', () => {
+    const state = createState('idle');
+    const result = tickAutoplay(state, 0.001);
+    expect(result.state).toBe('idle');
+  });
+
+  test('should return to idle from detecting when signal drops', () => {
+    const state = { ...createState('detecting'), detectingSince: Date.now() };
+    const result = tickAutoplay(state, 0.001);
+    expect(result.state).toBe('idle');
+  });
+
+  test('should transition from detecting to playing after sustain period', () => {
+    const now = Date.now();
+    const state = { ...createState('detecting'), detectingSince: now - 300 };
+    const result = tickAutoplay(state, 0.01, 0.002, now);
+    expect(result.state).toBe('playing');
+  });
+
+  test('should stay detecting before sustain period expires', () => {
+    const now = Date.now();
+    const state = { ...createState('detecting'), detectingSince: now - 100 };
+    const result = tickAutoplay(state, 0.01, 0.002, now);
+    expect(result.state).toBe('detecting');
+  });
+
+  test('should transition from playing to silence when signal drops', () => {
+    const state = createState('playing');
+    const result = tickAutoplay(state, 0.001);
+    expect(result.state).toBe('silence');
+    expect(result.silenceSince).not.toBeNull();
+  });
+
+  test('should return from silence to playing when signal resumes', () => {
+    const state = { ...createState('silence'), silenceSince: Date.now() };
+    const result = tickAutoplay(state, 0.01);
+    expect(result.state).toBe('playing');
+  });
+
+  test('should transition from silence to idle after timeout', () => {
+    const now = Date.now();
+    const state = { ...createState('silence'), silenceSince: now - 300001 };
+    const result = tickAutoplay(state, 0.001, 0.002, now);
+    expect(result.state).toBe('idle');
+  });
+
+  test('should stay in silence before timeout expires', () => {
+    const now = Date.now();
+    const state = { ...createState('silence'), silenceSince: now - 60000 };
+    const result = tickAutoplay(state, 0.001, 0.002, now);
+    expect(result.state).toBe('silence');
+  });
+});
+
+describe('Config Management', () => {
+  const DEFAULT_CONFIG = {
+    displayName: 'TestPi',
+    defaultInputId: null,
+    defaultOutputIds: [],
+    defaultVolume: 50,
+    autoplayEnabled: false,
+    autoplayThreshold: 0.002
+  };
+
+  test('should merge partial config updates', () => {
+    const config = { ...DEFAULT_CONFIG };
+    const partial = { displayName: 'NewName', defaultVolume: 75 };
+    const merged = { ...config, ...partial };
+    expect(merged.displayName).toBe('NewName');
+    expect(merged.defaultVolume).toBe(75);
+    expect(merged.defaultInputId).toBeNull();
+    expect(merged.autoplayEnabled).toBe(false);
+  });
+
+  test('should preserve unspecified fields during partial update', () => {
+    const config = { ...DEFAULT_CONFIG, displayName: 'Original', autoplayEnabled: true };
+    const partial = { defaultVolume: 80 };
+    const merged = { ...config, ...partial };
+    expect(merged.displayName).toBe('Original');
+    expect(merged.autoplayEnabled).toBe(true);
+    expect(merged.defaultVolume).toBe(80);
+  });
+
+  test('should handle empty partial update', () => {
+    const config = { ...DEFAULT_CONFIG };
+    const merged = { ...config, ...{} };
+    expect(merged).toEqual(DEFAULT_CONFIG);
+  });
+
+  test('should validate volume range', () => {
+    const volume = 150;
+    const clamped = Math.max(0, Math.min(100, volume));
+    expect(clamped).toBe(100);
+  });
+
+  test('should validate volume range low', () => {
+    const volume = -10;
+    const clamped = Math.max(0, Math.min(100, volume));
+    expect(clamped).toBe(0);
+  });
+
+  test('should handle missing config fields with defaults', () => {
+    const parsed = { displayName: 'Custom' };
+    const config = { ...DEFAULT_CONFIG, ...parsed };
+    expect(config.displayName).toBe('Custom');
+    expect(config.defaultOutputIds).toEqual([]);
+    expect(config.autoplayThreshold).toBe(0.002);
   });
 });
 

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -172,7 +172,7 @@ describe('RMS Audio Level Calculation', () => {
   });
 });
 
-describe('Autoplay State Machine', () => {
+describe('Autoconnect State Machine', () => {
   const DETECT_SUSTAIN_MS = 250;
   const SILENCE_TIMEOUT_MS = 300000;
 
@@ -186,7 +186,7 @@ describe('Autoplay State Machine', () => {
     };
   }
 
-  function tickAutoplay(state, rmsLevel, threshold = 0.002, now = Date.now()) {
+  function tickAutoconnect(state, rmsLevel, threshold = 0.002, now = Date.now()) {
     switch (state.state) {
       case 'paused':
         return state;
@@ -199,17 +199,17 @@ describe('Autoplay State Machine', () => {
         if (rmsLevel <= threshold) {
           return { ...state, state: 'idle', detectingSince: null };
         } else if (now - state.detectingSince >= DETECT_SUSTAIN_MS) {
-          return { ...state, state: 'playing', detectingSince: null };
+          return { ...state, state: 'connected', detectingSince: null };
         }
         return state;
-      case 'playing':
+      case 'connected':
         if (rmsLevel <= threshold) {
           return { ...state, state: 'silence', silenceSince: now };
         }
         return state;
       case 'silence':
         if (rmsLevel > threshold) {
-          return { ...state, state: 'playing', silenceSince: null };
+          return { ...state, state: 'connected', silenceSince: null };
         } else if (now - state.silenceSince >= SILENCE_TIMEOUT_MS) {
           return { ...state, state: 'idle', silenceSince: null };
         }
@@ -221,67 +221,67 @@ describe('Autoplay State Machine', () => {
 
   test('should stay paused when receiving audio', () => {
     const state = createState('paused');
-    const result = tickAutoplay(state, 0.1);
+    const result = tickAutoconnect(state, 0.1);
     expect(result.state).toBe('paused');
   });
 
   test('should transition from idle to detecting on signal', () => {
     const state = createState('idle');
-    const result = tickAutoplay(state, 0.01);
+    const result = tickAutoconnect(state, 0.01);
     expect(result.state).toBe('detecting');
     expect(result.detectingSince).not.toBeNull();
   });
 
   test('should stay idle when signal is below threshold', () => {
     const state = createState('idle');
-    const result = tickAutoplay(state, 0.001);
+    const result = tickAutoconnect(state, 0.001);
     expect(result.state).toBe('idle');
   });
 
   test('should return to idle from detecting when signal drops', () => {
     const state = { ...createState('detecting'), detectingSince: Date.now() };
-    const result = tickAutoplay(state, 0.001);
+    const result = tickAutoconnect(state, 0.001);
     expect(result.state).toBe('idle');
   });
 
   test('should transition from detecting to playing after sustain period', () => {
     const now = Date.now();
     const state = { ...createState('detecting'), detectingSince: now - 300 };
-    const result = tickAutoplay(state, 0.01, 0.002, now);
-    expect(result.state).toBe('playing');
+    const result = tickAutoconnect(state, 0.01, 0.002, now);
+    expect(result.state).toBe('connected');
   });
 
   test('should stay detecting before sustain period expires', () => {
     const now = Date.now();
     const state = { ...createState('detecting'), detectingSince: now - 100 };
-    const result = tickAutoplay(state, 0.01, 0.002, now);
+    const result = tickAutoconnect(state, 0.01, 0.002, now);
     expect(result.state).toBe('detecting');
   });
 
   test('should transition from playing to silence when signal drops', () => {
-    const state = createState('playing');
-    const result = tickAutoplay(state, 0.001);
+    const state = createState('connected');
+    const result = tickAutoconnect(state, 0.001);
     expect(result.state).toBe('silence');
     expect(result.silenceSince).not.toBeNull();
   });
 
   test('should return from silence to playing when signal resumes', () => {
     const state = { ...createState('silence'), silenceSince: Date.now() };
-    const result = tickAutoplay(state, 0.01);
-    expect(result.state).toBe('playing');
+    const result = tickAutoconnect(state, 0.01);
+    expect(result.state).toBe('connected');
   });
 
   test('should transition from silence to idle after timeout', () => {
     const now = Date.now();
     const state = { ...createState('silence'), silenceSince: now - 300001 };
-    const result = tickAutoplay(state, 0.001, 0.002, now);
+    const result = tickAutoconnect(state, 0.001, 0.002, now);
     expect(result.state).toBe('idle');
   });
 
   test('should stay in silence before timeout expires', () => {
     const now = Date.now();
     const state = { ...createState('silence'), silenceSince: now - 60000 };
-    const result = tickAutoplay(state, 0.001, 0.002, now);
+    const result = tickAutoconnect(state, 0.001, 0.002, now);
     expect(result.state).toBe('silence');
   });
 });
@@ -292,8 +292,8 @@ describe('Config Management', () => {
     defaultInputId: null,
     defaultOutputIds: [],
     defaultVolume: 50,
-    autoplayEnabled: false,
-    autoplayThreshold: 0.002
+    autoconnectEnabled: false,
+    autoconnectThreshold: 0.002
   };
 
   test('should merge partial config updates', () => {
@@ -303,15 +303,15 @@ describe('Config Management', () => {
     expect(merged.displayName).toBe('NewName');
     expect(merged.defaultVolume).toBe(75);
     expect(merged.defaultInputId).toBeNull();
-    expect(merged.autoplayEnabled).toBe(false);
+    expect(merged.autoconnectEnabled).toBe(false);
   });
 
   test('should preserve unspecified fields during partial update', () => {
-    const config = { ...DEFAULT_CONFIG, displayName: 'Original', autoplayEnabled: true };
+    const config = { ...DEFAULT_CONFIG, displayName: 'Original', autoconnectEnabled: true };
     const partial = { defaultVolume: 80 };
     const merged = { ...config, ...partial };
     expect(merged.displayName).toBe('Original');
-    expect(merged.autoplayEnabled).toBe(true);
+    expect(merged.autoconnectEnabled).toBe(true);
     expect(merged.defaultVolume).toBe(80);
   });
 
@@ -338,7 +338,7 @@ describe('Config Management', () => {
     const config = { ...DEFAULT_CONFIG, ...parsed };
     expect(config.displayName).toBe('Custom');
     expect(config.defaultOutputIds).toEqual([]);
-    expect(config.autoplayThreshold).toBe(0.002);
+    expect(config.autoconnectThreshold).toBe(0.002);
   });
 });
 

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -186,29 +186,38 @@ describe('Autoconnect State Machine', () => {
     };
   }
 
-  function tickAutoconnect(state, rmsLevel, threshold = 0.002, now = Date.now()) {
+  // Mirrors production logic: raw RMS for initial detection,
+  // smoothed RMS for steady-state decisions, hysteresis on exit
+  function tickAutoconnect(state, rawRms, { threshold = 0.005, smoothedRms = null, now = Date.now() } = {}) {
+    // If smoothedRms not provided, use rawRms (simple tests)
+    const smoothed = smoothedRms !== null ? smoothedRms : rawRms;
+
     switch (state.state) {
       case 'paused':
         return state;
       case 'idle':
-        if (rmsLevel > threshold) {
+        // Raw RMS — catch transients fast
+        if (rawRms > threshold) {
           return { ...state, state: 'detecting', detectingSince: now };
         }
         return state;
       case 'detecting':
-        if (rmsLevel <= threshold) {
+        // Raw RMS for sustain check
+        if (rawRms <= threshold) {
           return { ...state, state: 'idle', detectingSince: null };
         } else if (now - state.detectingSince >= DETECT_SUSTAIN_MS) {
           return { ...state, state: 'connected', detectingSince: null };
         }
         return state;
       case 'connected':
-        if (rmsLevel <= threshold) {
+        // Smoothed RMS with hysteresis — threshold/4 to exit
+        if (smoothed <= threshold / 4) {
           return { ...state, state: 'silence', silenceSince: now };
         }
         return state;
       case 'silence':
-        if (rmsLevel > threshold) {
+        // Smoothed RMS to return
+        if (smoothed > threshold) {
           return { ...state, state: 'connected', silenceSince: null };
         } else if (now - state.silenceSince >= SILENCE_TIMEOUT_MS) {
           return { ...state, state: 'idle', silenceSince: null };
@@ -225,7 +234,7 @@ describe('Autoconnect State Machine', () => {
     expect(result.state).toBe('paused');
   });
 
-  test('should transition from idle to detecting on signal', () => {
+  test('should transition from idle to detecting on raw signal above threshold', () => {
     const state = createState('idle');
     const result = tickAutoconnect(state, 0.01);
     expect(result.state).toBe('detecting');
@@ -238,50 +247,73 @@ describe('Autoconnect State Machine', () => {
     expect(result.state).toBe('idle');
   });
 
-  test('should return to idle from detecting when signal drops', () => {
+  test('should return to idle from detecting when raw signal drops', () => {
     const state = { ...createState('detecting'), detectingSince: Date.now() };
     const result = tickAutoconnect(state, 0.001);
     expect(result.state).toBe('idle');
   });
 
-  test('should transition from detecting to playing after sustain period', () => {
+  test('should transition from detecting to connected after sustain period', () => {
     const now = Date.now();
     const state = { ...createState('detecting'), detectingSince: now - 300 };
-    const result = tickAutoconnect(state, 0.01, 0.002, now);
+    const result = tickAutoconnect(state, 0.01, { now });
     expect(result.state).toBe('connected');
   });
 
   test('should stay detecting before sustain period expires', () => {
     const now = Date.now();
     const state = { ...createState('detecting'), detectingSince: now - 100 };
-    const result = tickAutoconnect(state, 0.01, 0.002, now);
+    const result = tickAutoconnect(state, 0.01, { now });
     expect(result.state).toBe('detecting');
   });
 
-  test('should transition from playing to silence when signal drops', () => {
+  // Hysteresis tests: connected → silence requires smoothed RMS below threshold/4
+  test('should stay connected when smoothed is above stop threshold', () => {
     const state = createState('connected');
-    const result = tickAutoconnect(state, 0.001);
-    expect(result.state).toBe('silence');
-    expect(result.silenceSince).not.toBeNull();
+    // smoothed at 0.002, which is above 0.005/4 = 0.00125
+    const result = tickAutoconnect(state, 0.002, { smoothedRms: 0.002 });
+    expect(result.state).toBe('connected');
   });
 
-  test('should return from silence to playing when signal resumes', () => {
-    const state = { ...createState('silence'), silenceSince: Date.now() };
-    const result = tickAutoconnect(state, 0.01);
+  test('should transition to silence only when smoothed drops below threshold/4', () => {
+    const state = createState('connected');
+    // smoothed at 0.001, which is below 0.005/4 = 0.00125
+    const result = tickAutoconnect(state, 0.001, { smoothedRms: 0.001 });
+    expect(result.state).toBe('silence');
+  });
+
+  test('should NOT transition to silence on brief raw dip if smoothed is still high', () => {
+    const state = createState('connected');
+    // Raw dips but smoothed stays up — this is the key hysteresis test
+    const result = tickAutoconnect(state, 0.0005, { smoothedRms: 0.003 });
     expect(result.state).toBe('connected');
+  });
+
+  // Silence → connected uses smoothed RMS (filters surface noise pops)
+  test('should return from silence to connected when smoothed signal rises', () => {
+    const state = { ...createState('silence'), silenceSince: Date.now() };
+    const result = tickAutoconnect(state, 0.01, { smoothedRms: 0.01 });
+    expect(result.state).toBe('connected');
+  });
+
+  test('should stay in silence when only raw spikes but smoothed is low', () => {
+    const state = { ...createState('silence'), silenceSince: Date.now() };
+    // Raw spike (surface noise pop) but smoothed stays below threshold
+    const result = tickAutoconnect(state, 0.01, { smoothedRms: 0.002 });
+    expect(result.state).toBe('silence');
   });
 
   test('should transition from silence to idle after timeout', () => {
     const now = Date.now();
     const state = { ...createState('silence'), silenceSince: now - 300001 };
-    const result = tickAutoconnect(state, 0.001, 0.002, now);
+    const result = tickAutoconnect(state, 0.001, { smoothedRms: 0.001, now });
     expect(result.state).toBe('idle');
   });
 
   test('should stay in silence before timeout expires', () => {
     const now = Date.now();
     const state = { ...createState('silence'), silenceSince: now - 60000 };
-    const result = tickAutoconnect(state, 0.001, 0.002, now);
+    const result = tickAutoconnect(state, 0.001, { smoothedRms: 0.001, now });
     expect(result.state).toBe('silence');
   });
 });

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -374,6 +374,125 @@ describe('Config Management', () => {
   });
 });
 
+describe('Input Process Management', () => {
+  // Models the generation counter pattern used in index.js.
+  // Each input spawn increments the generation; stale handlers are no-ops.
+  function createInputManager(maxAttempts = 5) {
+    let generation = 0;
+    let restartAttempts = 0;
+    let shouldExit = false;
+    const restartLog = [];
+
+    return {
+      get generation() { return generation; },
+      get restartAttempts() { return restartAttempts; },
+      get shouldExit() { return shouldExit; },
+      get restartLog() { return restartLog; },
+
+      startInput(devId) {
+        generation++;
+        restartAttempts = 0;
+        restartLog.push({ action: 'start', devId, generation });
+        return generation;
+      },
+
+      handleExit(exitGeneration, devId) {
+        if (exitGeneration !== generation) return 'stale';
+        restartLog.push({ action: 'exit', devId, generation: exitGeneration });
+        return this.scheduleRestart(devId, exitGeneration);
+      },
+
+      scheduleRestart(devId, restartGeneration) {
+        if (restartGeneration !== generation) return 'stale';
+        restartAttempts++;
+        if (restartAttempts > maxAttempts) {
+          shouldExit = true;
+          restartLog.push({ action: 'exhausted', devId });
+          return 'exhausted';
+        }
+        restartLog.push({ action: 'restart', devId, attempt: restartAttempts });
+        return 'restart';
+      },
+
+      watchdogRestart(devId) {
+        restartAttempts = 0;
+        generation++;
+        restartLog.push({ action: 'watchdog', devId, generation });
+        return generation;
+      }
+    };
+  }
+
+  test('stale exit handler is ignored when generation has advanced', () => {
+    const manager = createInputManager();
+    const gen1 = manager.startInput('plughw:0,0');
+    manager.startInput('plughw:1,0');
+    const result = manager.handleExit(gen1, 'plughw:0,0');
+    expect(result).toBe('stale');
+    expect(manager.restartAttempts).toBe(0);
+  });
+
+  test('current-generation exit handler triggers restart', () => {
+    const manager = createInputManager();
+    const gen = manager.startInput('plughw:0,0');
+    const result = manager.handleExit(gen, 'plughw:0,0');
+    expect(result).toBe('restart');
+    expect(manager.restartAttempts).toBe(1);
+  });
+
+  test('restart attempts exhaust and signal exit', () => {
+    const manager = createInputManager(3);
+    const gen = manager.startInput('plughw:0,0');
+    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('restart');
+    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('restart');
+    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('restart');
+    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('exhausted');
+    expect(manager.shouldExit).toBe(true);
+  });
+
+  test('manual input switch resets restart counter', () => {
+    const manager = createInputManager();
+    const gen1 = manager.startInput('plughw:0,0');
+    manager.scheduleRestart('plughw:0,0', gen1);
+    manager.scheduleRestart('plughw:0,0', gen1);
+    expect(manager.restartAttempts).toBe(2);
+
+    manager.startInput('plughw:1,0');
+    expect(manager.restartAttempts).toBe(0);
+  });
+
+  test('watchdog restart resets counter and advances generation', () => {
+    const manager = createInputManager();
+    const gen1 = manager.startInput('plughw:0,0');
+    manager.scheduleRestart('plughw:0,0', gen1);
+    manager.scheduleRestart('plughw:0,0', gen1);
+    expect(manager.restartAttempts).toBe(2);
+
+    const gen2 = manager.watchdogRestart('plughw:0,0');
+    expect(manager.restartAttempts).toBe(0);
+    expect(gen2).toBeGreaterThan(gen1);
+
+    const staleResult = manager.scheduleRestart('plughw:0,0', gen1);
+    expect(staleResult).toBe('stale');
+  });
+
+  test('clean exit (code 0) still triggers restart', () => {
+    const manager = createInputManager();
+    const gen = manager.startInput('plughw:0,0');
+    const result = manager.handleExit(gen, 'plughw:0,0');
+    expect(result).toBe('restart');
+  });
+
+  test('pending restart becomes no-op after manual switch', () => {
+    const manager = createInputManager();
+    const gen1 = manager.startInput('plughw:0,0');
+    manager.startInput('plughw:1,0');
+    const result = manager.scheduleRestart('plughw:0,0', gen1);
+    expect(result).toBe('stale');
+    expect(manager.restartAttempts).toBe(0);
+  });
+});
+
 // Note: Full integration tests would require:
 // 1. Mock ALSA devices
 // 2. Mock AirPlay receivers

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -493,6 +493,37 @@ describe('Input Process Management', () => {
   });
 });
 
+describe('arecord Spawn Configuration', () => {
+  test('should include buffer-size flag in arecord arguments', () => {
+    const devId = 'plughw:0,0';
+    const args = ["-D", devId, "-c", "2", "-f", "S16_LE", "-r", "44100", "--buffer-size=131072"];
+    expect(args).toContain('--buffer-size=131072');
+    expect(args.indexOf('--buffer-size=131072')).toBe(args.length - 1);
+  });
+});
+
+describe('SIGTERM Cleanup Timing', () => {
+  test('should allow 2000ms for graceful SIGTERM before SIGKILL', () => {
+    const SIGKILL_TIMEOUT = 2000;
+    expect(SIGKILL_TIMEOUT).toBeGreaterThanOrEqual(2000);
+    expect(SIGKILL_TIMEOUT).toBeLessThanOrEqual(5000);
+  });
+});
+
+describe('Memory Logging', () => {
+  test('should format memory usage as human-readable MB values', () => {
+    const mem = { rss: 52428800, heapUsed: 20971520, heapTotal: 33554432, external: 1048576 };
+    const formatted = `rss=${Math.round(mem.rss / 1024 / 1024)}MB heap=${Math.round(mem.heapUsed / 1024 / 1024)}/${Math.round(mem.heapTotal / 1024 / 1024)}MB external=${Math.round(mem.external / 1024 / 1024)}MB`;
+    expect(formatted).toBe('rss=50MB heap=20/32MB external=1MB');
+  });
+
+  test('should handle zero memory values', () => {
+    const mem = { rss: 0, heapUsed: 0, heapTotal: 0, external: 0 };
+    const formatted = `rss=${Math.round(mem.rss / 1024 / 1024)}MB heap=${Math.round(mem.heapUsed / 1024 / 1024)}/${Math.round(mem.heapTotal / 1024 / 1024)}MB external=${Math.round(mem.external / 1024 / 1024)}MB`;
+    expect(formatted).toBe('rss=0MB heap=0/0MB external=0MB');
+  });
+});
+
 // Note: Full integration tests would require:
 // 1. Mock ALSA devices
 // 2. Mock AirPlay receivers

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -377,54 +377,20 @@ describe('Config Management', () => {
 describe('Input Process Management', () => {
   // Models the generation counter pattern used in index.js.
   // Each input spawn increments the generation; stale handlers are no-ops.
-  const USB_RESET_ATTEMPT = 3;
-
-  function createInputManager(maxAttempts = 3) {
+  function createInputManager() {
     let generation = 0;
-    let restartAttempts = 0;
-    let shouldExit = false;
-    const restartLog = [];
 
     return {
       get generation() { return generation; },
-      get restartAttempts() { return restartAttempts; },
-      get shouldExit() { return shouldExit; },
-      get restartLog() { return restartLog; },
 
       startInput(devId) {
         generation++;
-        restartAttempts = 0;
-        restartLog.push({ action: 'start', devId, generation });
         return generation;
       },
 
-      handleExit(exitGeneration, devId) {
+      handleExit(exitGeneration) {
         if (exitGeneration !== generation) return 'stale';
-        restartLog.push({ action: 'exit', devId, generation: exitGeneration });
-        return this.scheduleRestart(devId, exitGeneration);
-      },
-
-      scheduleRestart(devId, restartGeneration) {
-        if (restartGeneration !== generation) return 'stale';
-        restartAttempts++;
-        if (restartAttempts > maxAttempts) {
-          shouldExit = true;
-          restartLog.push({ action: 'exhausted', devId });
-          return 'exhausted';
-        }
-        if (restartAttempts === USB_RESET_ATTEMPT) {
-          restartLog.push({ action: 'usb-reset', devId, attempt: restartAttempts });
-          return 'usb-reset';
-        }
-        restartLog.push({ action: 'restart', devId, attempt: restartAttempts });
-        return 'restart';
-      },
-
-      watchdogRestart(devId) {
-        restartAttempts = 0;
-        generation++;
-        restartLog.push({ action: 'watchdog', devId, generation });
-        return generation;
+        return 'exit';
       }
     };
   }
@@ -433,100 +399,21 @@ describe('Input Process Management', () => {
     const manager = createInputManager();
     const gen1 = manager.startInput('plughw:0,0');
     manager.startInput('plughw:1,0');
-    const result = manager.handleExit(gen1, 'plughw:0,0');
-    expect(result).toBe('stale');
-    expect(manager.restartAttempts).toBe(0);
+    expect(manager.handleExit(gen1)).toBe('stale');
   });
 
-  test('current-generation exit handler triggers restart', () => {
+  test('current-generation exit triggers process exit', () => {
     const manager = createInputManager();
     const gen = manager.startInput('plughw:0,0');
-    const result = manager.handleExit(gen, 'plughw:0,0');
-    expect(result).toBe('restart');
-    expect(manager.restartAttempts).toBe(1);
+    expect(manager.handleExit(gen)).toBe('exit');
   });
 
-  test('restart attempts exhaust and signal exit', () => {
-    const manager = createInputManager(3);
-    const gen = manager.startInput('plughw:0,0');
-    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('restart');
-    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('restart');
-    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('usb-reset');
-    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('exhausted');
-    expect(manager.shouldExit).toBe(true);
-  });
-
-  test('manual input switch resets restart counter', () => {
+  test('manual input switch advances generation', () => {
     const manager = createInputManager();
     const gen1 = manager.startInput('plughw:0,0');
-    manager.scheduleRestart('plughw:0,0', gen1);
-    manager.scheduleRestart('plughw:0,0', gen1);
-    expect(manager.restartAttempts).toBe(2);
-
-    manager.startInput('plughw:1,0');
-    expect(manager.restartAttempts).toBe(0);
-  });
-
-  test('watchdog restart resets counter and advances generation', () => {
-    const manager = createInputManager();
-    const gen1 = manager.startInput('plughw:0,0');
-    manager.scheduleRestart('plughw:0,0', gen1);
-    manager.scheduleRestart('plughw:0,0', gen1);
-    expect(manager.restartAttempts).toBe(2);
-
-    const gen2 = manager.watchdogRestart('plughw:0,0');
-    expect(manager.restartAttempts).toBe(0);
+    const gen2 = manager.startInput('plughw:1,0');
     expect(gen2).toBeGreaterThan(gen1);
-
-    const staleResult = manager.scheduleRestart('plughw:0,0', gen1);
-    expect(staleResult).toBe('stale');
-  });
-
-  test('clean exit (code 0) still triggers restart', () => {
-    const manager = createInputManager();
-    const gen = manager.startInput('plughw:0,0');
-    const result = manager.handleExit(gen, 'plughw:0,0');
-    expect(result).toBe('restart');
-  });
-
-  test('pending restart becomes no-op after manual switch', () => {
-    const manager = createInputManager();
-    const gen1 = manager.startInput('plughw:0,0');
-    manager.startInput('plughw:1,0');
-    const result = manager.scheduleRestart('plughw:0,0', gen1);
-    expect(result).toBe('stale');
-    expect(manager.restartAttempts).toBe(0);
-  });
-
-  test('USB reset triggers on attempt 3', () => {
-    const manager = createInputManager();
-    const gen = manager.startInput('plughw:0,0');
-    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('restart');
-    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('restart');
-    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('usb-reset');
-    expect(manager.restartLog).toContainEqual({ action: 'usb-reset', devId: 'plughw:0,0', attempt: 3 });
-  });
-
-  test('USB reset does not prevent exhaustion if retries continue failing', () => {
-    const manager = createInputManager();
-    const gen = manager.startInput('plughw:0,0');
-    manager.scheduleRestart('plughw:0,0', gen); // 1
-    manager.scheduleRestart('plughw:0,0', gen); // 2
-    manager.scheduleRestart('plughw:0,0', gen); // 3 — usb-reset
-    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('exhausted');
-    expect(manager.shouldExit).toBe(true);
-  });
-
-  test('USB device ID parsing from sysfs path', () => {
-    const devicePath = '/sys/devices/platform/soc/3f980000.usb/usb1/1-1/1-1:1.0';
-    const usbDevice = devicePath.split('/').find(segment => /^\d+-\d+$/.test(segment));
-    expect(usbDevice).toBe('1-1');
-  });
-
-  test('USB device ID parsing handles multi-level paths', () => {
-    const devicePath = '/sys/devices/platform/soc/3f980000.usb/usb1/1-1/1-1.2/1-1.2:1.0';
-    const usbDevice = devicePath.split('/').find(segment => /^\d+-\d+$/.test(segment));
-    expect(usbDevice).toBe('1-1');
+    expect(manager.handleExit(gen1)).toBe('stale');
   });
 });
 

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -379,7 +379,7 @@ describe('Input Process Management', () => {
   // Each input spawn increments the generation; stale handlers are no-ops.
   const USB_RESET_ATTEMPT = 3;
 
-  function createInputManager(maxAttempts = 5) {
+  function createInputManager(maxAttempts = 3) {
     let generation = 0;
     let restartAttempts = 0;
     let shouldExit = false;
@@ -513,8 +513,6 @@ describe('Input Process Management', () => {
     manager.scheduleRestart('plughw:0,0', gen); // 1
     manager.scheduleRestart('plughw:0,0', gen); // 2
     manager.scheduleRestart('plughw:0,0', gen); // 3 — usb-reset
-    manager.scheduleRestart('plughw:0,0', gen); // 4
-    manager.scheduleRestart('plughw:0,0', gen); // 5
     expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('exhausted');
     expect(manager.shouldExit).toBe(true);
   });

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -377,6 +377,8 @@ describe('Config Management', () => {
 describe('Input Process Management', () => {
   // Models the generation counter pattern used in index.js.
   // Each input spawn increments the generation; stale handlers are no-ops.
+  const USB_RESET_ATTEMPT = 3;
+
   function createInputManager(maxAttempts = 5) {
     let generation = 0;
     let restartAttempts = 0;
@@ -409,6 +411,10 @@ describe('Input Process Management', () => {
           shouldExit = true;
           restartLog.push({ action: 'exhausted', devId });
           return 'exhausted';
+        }
+        if (restartAttempts === USB_RESET_ATTEMPT) {
+          restartLog.push({ action: 'usb-reset', devId, attempt: restartAttempts });
+          return 'usb-reset';
         }
         restartLog.push({ action: 'restart', devId, attempt: restartAttempts });
         return 'restart';
@@ -445,7 +451,7 @@ describe('Input Process Management', () => {
     const gen = manager.startInput('plughw:0,0');
     expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('restart');
     expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('restart');
-    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('restart');
+    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('usb-reset');
     expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('exhausted');
     expect(manager.shouldExit).toBe(true);
   });
@@ -490,6 +496,39 @@ describe('Input Process Management', () => {
     const result = manager.scheduleRestart('plughw:0,0', gen1);
     expect(result).toBe('stale');
     expect(manager.restartAttempts).toBe(0);
+  });
+
+  test('USB reset triggers on attempt 3', () => {
+    const manager = createInputManager();
+    const gen = manager.startInput('plughw:0,0');
+    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('restart');
+    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('restart');
+    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('usb-reset');
+    expect(manager.restartLog).toContainEqual({ action: 'usb-reset', devId: 'plughw:0,0', attempt: 3 });
+  });
+
+  test('USB reset does not prevent exhaustion if retries continue failing', () => {
+    const manager = createInputManager();
+    const gen = manager.startInput('plughw:0,0');
+    manager.scheduleRestart('plughw:0,0', gen); // 1
+    manager.scheduleRestart('plughw:0,0', gen); // 2
+    manager.scheduleRestart('plughw:0,0', gen); // 3 — usb-reset
+    manager.scheduleRestart('plughw:0,0', gen); // 4
+    manager.scheduleRestart('plughw:0,0', gen); // 5
+    expect(manager.scheduleRestart('plughw:0,0', gen)).toBe('exhausted');
+    expect(manager.shouldExit).toBe(true);
+  });
+
+  test('USB device ID parsing from sysfs path', () => {
+    const devicePath = '/sys/devices/platform/soc/3f980000.usb/usb1/1-1/1-1:1.0';
+    const usbDevice = devicePath.split('/').find(segment => /^\d+-\d+$/.test(segment));
+    expect(usbDevice).toBe('1-1');
+  });
+
+  test('USB device ID parsing handles multi-level paths', () => {
+    const devicePath = '/sys/devices/platform/soc/3f980000.usb/usb1/1-1/1-1.2/1-1.2:1.0';
+    const usbDevice = devicePath.split('/').find(segment => /^\d+-\d+$/.test(segment));
+    expect(usbDevice).toBe('1-1');
   });
 });
 


### PR DESCRIPTION
## Summary
- **Autoconnect state machine**: Detects audio on the input via RMS monitoring and automatically routes to configured default AirPlay speakers. Includes sustain detection (filters bumps/pops), exponential moving average for silence detection, and hysteresis to avoid flip-flopping during quiet passages.
- **Web UI**: Full autoconnect controls, settings panel (display name, default input/outputs, volume, threshold), input mode dropdown, and save confirmation.
- **Process management**: Generation counter pattern for arecord lifecycle, input stream watchdog, immediate bail to systemd on failure.
- **arecord -t raw fix**: Root cause of the ~3.4h arecord death cycle was arecord's WAV format 2GB file size limit (2^31 bytes / 176,400 bytes/sec = 3h22m54s). Adding `-t raw` removes the limit entirely.
- **systemd service**: StartLimit rate-limiting, `--max-old-space-size=128` heap cap, `--buffer-size=131072` for arecord.
- **API docs**: Updated API.md with autoconnect events, config events, thresholds.
- **Tests**: Autoconnect state machine, RMS calculation, config management, input process management.

## Test plan
- [x] `node -c index.js` syntax check
- [x] `npm test` — 46 tests pass
- [x] Deployed to Pi, verified autoconnect triggers on vinyl playback
- [x] Confirmed `-t raw` fix: 12+ hours uptime without arecord failure (previously died every 3h23m)
- [x] Verified process.exit(1) escalation to systemd on arecord failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)