### PR TITLE
Extract testable device helpers and fix PCM device-list propagation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Check logs: `ssh pi@PattyPi.local 'journalctl -u babelpod -f'`
 
 ## Architecture
 
-The entire server is a single file (`index.js`, ~900 lines). The web UI is a single file (`index.html`).
+The server lives in `index.js` (~1100 lines). Pure, hardware-free helpers (PCM device parsing, AirPlay mDNS record parsing, output unification) live in `lib/devices.js` so they can be unit tested directly. The web UI is a single file (`index.html`).
 
 ### Audio Pipeline
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const dnssd = require('dnssd2');
 const AirTunes = require('airtunes2');
 const { hostname } = require('os');
 const path = require('path');
+const { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume } = require('./lib/devices');
 
 // =======================
 // 1a) Log level
@@ -529,76 +530,13 @@ let unifiedOutputs = [];
 function scanPcmDevices() {
   try {
     const text = fs.readFileSync('/proc/asound/pcm', 'utf8');
-    const lines = text.split('\n').filter(line => line.trim() !== '');
-    const all = lines.map(line => {
-      const parts = line.split(':');
-      if (parts.length < 3) return null;
-      const devName = parts[2].trim();
-      const devId = "plughw:" + parts[0].split("-").map(x => parseInt(x, 10)).join(",");
-      return {
-        id: devId,
-        name: devName,
-        output: parts.some(t => t.includes("playback")),
-        input: parts.some(t => t.includes("capture"))
-      };
-    }).filter(Boolean);
-    availablePcmOutputs = all.filter(d => d.output);
-    availablePcmInputs = all.filter(d => d.input);
+    const { outputs, inputs } = parsePcmDevices(text);
+    availablePcmOutputs = outputs;
+    availablePcmInputs = inputs;
   } catch (e) {
     console.error("Error scanning /proc/asound/pcm:", e);
     // Don't crash - just log and continue with empty lists
   }
-}
-
-// Organize available outputs into a single list
-function buildUnifiedOutputs() {
-  let local = availablePcmOutputs.map(o => ({
-    uiId: o.id,
-    name: o.name + ' - Output',
-    isStereo: false,
-    devices: [{ localId: o.id }]
-  }));
-
-  // unify airplay outputs that might appear multiple times if it's the same device
-  // we can unify them by name and host:port, ignoring duplicates
-  let unique = {};
-  for (const device of availableAirplayOutputs) {
-    // create a key to unify duplicates
-    const key = (device.name || "") + "_" + device.host + "_" + device.port;
-    if (!unique[key]) {
-      unique[key] = device;
-    }
-  }
-  let cleanedAirplayOutputs = Object.values(unique);
-
-  let grouped = {};
-  for (const device of cleanedAirplayOutputs) {
-    const st = device.stereo || `${device.host}:${device.port}`;
-    if (!grouped[st]) grouped[st] = [];
-    grouped[st].push(device);
-  }
-
-  let air = [];
-  for (const stereoName in grouped) {
-    const arr = grouped[stereoName];
-    if (arr.length === 1) {
-      const d = arr[0];
-      air.push({
-        uiId: 'air:' + d.name,
-        name: (d.name || d.host) + ' - AirPlay',
-        isStereo: false,
-        devices: [{ host: d.host, port: d.port, isStereo: false }]
-      });
-    } else {
-      air.push({
-        uiId: 'airpair:' + stereoName,
-        name: stereoName + ' - AirPlay Stereo',
-        isStereo: true,
-        devices: arr.map(d => ({ host: d.host, port: d.port, isStereo: true }))
-      });
-    }
-  }
-  return local.concat(air);
 }
 
 // Build clean payloads for clients (strip server internals)
@@ -628,7 +566,7 @@ function buildStatePayload() {
 
 // Emit updates to clients
 function updateAllOutputs() {
-  unifiedOutputs = buildUnifiedOutputs();
+  unifiedOutputs = buildUnifiedOutputs(availablePcmOutputs, availableAirplayOutputs);
   io.emit('outputs', { outputs: buildCleanOutputs() });
 }
 function updateAllInputs() {
@@ -640,6 +578,7 @@ function updateAllInputs() {
 if (!process.env.DISABLE_PCM) {
   console.log("PCM device scanning enabled");
   scanPcmDevices();
+  unifiedOutputs = buildUnifiedOutputs(availablePcmOutputs, availableAirplayOutputs);
   // Auto-select input on startup: prefer config default, then first available
   if (currentInput === "void" && availablePcmInputs.length > 0) {
     const configuredInput = config.defaultInputId && availablePcmInputs.some(d => d.id === config.defaultInputId)
@@ -650,7 +589,15 @@ if (!process.env.DISABLE_PCM) {
     currentInput = configuredInput;
     startArecordForDevice(configuredInput, false);
   }
-  setInterval(scanPcmDevices, 10000);
+  // Rescan periodically and notify clients when devices appear or disappear
+  setInterval(() => {
+    const before = JSON.stringify([availablePcmInputs, availablePcmOutputs]);
+    scanPcmDevices();
+    if (JSON.stringify([availablePcmInputs, availablePcmOutputs]) !== before) {
+      updateAllInputs();
+      updateAllOutputs();
+    }
+  }, 10000);
 } else {
   console.log("PCM device scanning disabled via DISABLE_PCM environment variable");
 }
@@ -692,98 +639,62 @@ if (blue) {
 // Use dnssd2 for better service change/down event handling
 let browser = dnssd.Browser(dnssd.tcp('airplay'));
 
-browser.on('serviceUp', data => {
+// serviceUp and serviceChanged share the same upsert logic; only notify
+// clients when the device list actually changed.
+function upsertAirplayDevice(data, eventName) {
   try {
-    if (!data.fullname || !data.addresses?.length) return;
-    const match = /(.*)\._airplay\._tcp\.local/.exec(data.fullname);
-    if (match && match.length > 1) {
-      const address = data.addresses[0];
-      const port = data.port;
-      const st = data.txt?.gpn || null;
-      if (!availableAirplayOutputs.some(o => o.host === address && o.port === port)) {
-        availableAirplayOutputs.push({
-          name: match[1],
-          stereo: st,
-          host: address,
-          port
-        });
-        console.log(`AirPlay device discovered: ${match[1]} at ${address}:${port}`);
-        updateAllOutputs();
-      }
+    const service = parseAirplayService(data);
+    if (!service) return;
+    const existing = availableAirplayOutputs.find(o => o.host === service.host && o.port === service.port);
+    if (!existing) {
+      availableAirplayOutputs.push(service);
+      console.log(`AirPlay device discovered: ${service.name} at ${service.host}:${service.port}`);
+      updateAllOutputs();
+    } else if (existing.name !== service.name || existing.stereo !== service.stereo) {
+      existing.name = service.name;
+      existing.stereo = service.stereo;
+      console.log(`AirPlay device updated: ${service.name} at ${service.host}:${service.port}`);
+      updateAllOutputs();
     }
   } catch (e) {
-    console.error("Error processing mDNS serviceUp:", e);
+    console.error(`Error processing mDNS ${eventName}:`, e);
   }
-});
+}
 
-browser.on('serviceChanged', data => {
-  try {
-    if (!data.fullname || !data.addresses?.length) return;
-    const match = /(.*)\._airplay\._tcp\.local/.exec(data.fullname);
-    if (match && match.length > 1) {
-      const address = data.addresses[0];
-      const port = data.port;
-      const st = data.txt?.gpn || null;
-      const oldId = 'airplay_' + address + '_' + port;
-      
-      // Find and update existing device
-      const device = availableAirplayOutputs.find(o => o.host === address && o.port === port);
-      if (device) {
-        device.name = match[1];
-        device.stereo = st;
-        console.log(`AirPlay device updated: ${match[1]} at ${address}:${port}`);
-        updateAllOutputs();
-      } else {
-        // Device not found, treat as new
-        availableAirplayOutputs.push({
-          name: match[1],
-          stereo: st,
-          host: address,
-          port
-        });
-        console.log(`AirPlay device added via change event: ${match[1]} at ${address}:${port}`);
-        updateAllOutputs();
-      }
-    }
-  } catch (e) {
-    console.error("Error processing mDNS serviceChanged:", e);
-  }
-});
+browser.on('serviceUp', data => upsertAirplayDevice(data, 'serviceUp'));
+browser.on('serviceChanged', data => upsertAirplayDevice(data, 'serviceChanged'));
 
 browser.on('serviceDown', data => {
   try {
-    if (!data.fullname || !data.addresses?.length) return;
-    const match = /(.*)\._airplay\._tcp\.local/.exec(data.fullname);
-    if (match && match.length > 1) {
-      const address = data.addresses[0];
-      const port = data.port;
-      const beforeCount = availableAirplayOutputs.length;
-      availableAirplayOutputs = availableAirplayOutputs.filter(
-        o => !(o.host === address && o.port === port)
-      );
-      if (availableAirplayOutputs.length < beforeCount) {
-        console.log(`AirPlay device removed: ${match[1]} at ${address}:${port}`);
+    const service = parseAirplayService(data);
+    if (!service) return;
+    const { name, host, port } = service;
+    const beforeCount = availableAirplayOutputs.length;
+    availableAirplayOutputs = availableAirplayOutputs.filter(
+      o => !(o.host === host && o.port === port)
+    );
+    if (availableAirplayOutputs.length < beforeCount) {
+      console.log(`AirPlay device removed: ${name} at ${host}:${port}`);
 
-        // Stop streaming to the removed device
-        const deviceKey = `${address}:${port}`;
-        if (activeAirPlayDevices.includes(deviceKey)) {
-          try {
-            airtunes.stop(deviceKey);
-          } catch (e) {
-            console.error(`Error stopping removed AirPlay device ${deviceKey}:`, e);
-          }
-          activeAirPlayDevices = activeAirPlayDevices.filter(k => k !== deviceKey);
+      // Stop streaming to the removed device
+      const deviceKey = `${host}:${port}`;
+      if (activeAirPlayDevices.includes(deviceKey)) {
+        try {
+          airtunes.stop(deviceKey);
+        } catch (e) {
+          console.error(`Error stopping removed AirPlay device ${deviceKey}:`, e);
         }
+        activeAirPlayDevices = activeAirPlayDevices.filter(k => k !== deviceKey);
+      }
 
-        updateAllOutputs();
+      updateAllOutputs();
 
-        // Remove offline devices from selectedOutputs
-        const validIds = new Set(unifiedOutputs.map(o => o.uiId));
-        const cleanedOutputs = selectedOutputs.filter(id => validIds.has(id));
-        if (cleanedOutputs.length !== selectedOutputs.length) {
-          selectedOutputs = cleanedOutputs;
-          io.emit('output', { ids: selectedOutputs });
-        }
+      // Remove offline devices from selectedOutputs
+      const validIds = new Set(unifiedOutputs.map(o => o.uiId));
+      const cleanedOutputs = selectedOutputs.filter(id => validIds.has(id));
+      if (cleanedOutputs.length !== selectedOutputs.length) {
+        selectedOutputs = cleanedOutputs;
+        io.emit('output', { ids: selectedOutputs });
       }
     }
   } catch (e) {
@@ -1063,12 +974,12 @@ io.on('connection', socket => {
 
   socket.on('setVolume', (data) => {
     const vol = data?.value;
-    if (typeof vol !== 'number') return;
+    if (typeof vol !== 'number' || !Number.isFinite(vol)) return;
     console.log("Changing output volume to:", vol);
 
     if (socket.id !== sessionOwner) return;
     try {
-      volume = vol;
+      volume = clampVolume(vol);
       // Set volume on all active AirPlay devices
       activeAirPlayDevices.forEach(deviceKey => {
         try {
@@ -1158,7 +1069,7 @@ process.on('unhandledRejection', (reason, promise) => {
 });
 
 // Graceful shutdown
-process.on('SIGINT', () => {
+function shutdownGracefully() {
   console.log("\nShutting down gracefully...");
   cleanupCurrentInput();
   activeLocalOutputs.forEach(o => {
@@ -1169,17 +1080,7 @@ process.on('SIGINT', () => {
     }
   });
   process.exit(0);
-});
+}
 
-process.on('SIGTERM', () => {
-  console.log("\nShutting down gracefully...");
-  cleanupCurrentInput();
-  activeLocalOutputs.forEach(o => {
-    try {
-      o.process.kill();
-    } catch (e) {
-      console.error("Error killing local output:", e);
-    }
-  });
-  process.exit(0);
-});
+process.on('SIGINT', shutdownGracefully);
+process.on('SIGTERM', shutdownGracefully);

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -1,0 +1,99 @@
+/*
+  Pure device-list helpers used by the server (index.js) and unit tests.
+  No I/O here — callers read /proc/asound/pcm, mDNS records, etc. and pass
+  the raw data in.
+*/
+
+// Parse the contents of /proc/asound/pcm into input/output device lists.
+function parsePcmDevices(text) {
+  const lines = text.split('\n').filter(line => line.trim() !== '');
+  const all = lines.map(line => {
+    const parts = line.split(':');
+    if (parts.length < 3) return null;
+    const deviceName = parts[2].trim();
+    const deviceId = "plughw:" + parts[0].split("-").map(x => parseInt(x, 10)).join(",");
+    return {
+      id: deviceId,
+      name: deviceName,
+      output: parts.some(t => t.includes("playback")),
+      input: parts.some(t => t.includes("capture"))
+    };
+  }).filter(Boolean);
+  return {
+    outputs: all.filter(d => d.output),
+    inputs: all.filter(d => d.input)
+  };
+}
+
+// Parse an mDNS _airplay._tcp service record into a device descriptor,
+// or null if the record is not a usable AirPlay service.
+function parseAirplayService(data) {
+  if (!data.fullname || !data.addresses?.length) return null;
+  const match = /(.*)\._airplay\._tcp\.local/.exec(data.fullname);
+  if (!match || match.length < 2) return null;
+  return {
+    name: match[1],
+    stereo: data.txt?.gpn || null,
+    host: data.addresses[0],
+    port: data.port
+  };
+}
+
+// Organize available outputs into a single list for clients.
+// Deduplicates AirPlay devices by name+host:port and groups stereo pairs
+// (devices sharing a gpn TXT record) into one selectable output.
+function buildUnifiedOutputs(availablePcmOutputs, availableAirplayOutputs) {
+  let local = availablePcmOutputs.map(o => ({
+    uiId: o.id,
+    name: o.name + ' - Output',
+    isStereo: false,
+    devices: [{ localId: o.id }]
+  }));
+
+  // unify airplay outputs that might appear multiple times if it's the same device
+  // we can unify them by name and host:port, ignoring duplicates
+  let unique = {};
+  for (const device of availableAirplayOutputs) {
+    const key = (device.name || "") + "_" + device.host + "_" + device.port;
+    if (!unique[key]) {
+      unique[key] = device;
+    }
+  }
+  let cleanedAirplayOutputs = Object.values(unique);
+
+  let grouped = {};
+  for (const device of cleanedAirplayOutputs) {
+    const st = device.stereo || `${device.host}:${device.port}`;
+    if (!grouped[st]) grouped[st] = [];
+    grouped[st].push(device);
+  }
+
+  let air = [];
+  for (const stereoName in grouped) {
+    const arr = grouped[stereoName];
+    if (arr.length === 1) {
+      const d = arr[0];
+      air.push({
+        uiId: 'air:' + d.name,
+        name: (d.name || d.host) + ' - AirPlay',
+        isStereo: false,
+        devices: [{ host: d.host, port: d.port, isStereo: false }]
+      });
+    } else {
+      air.push({
+        uiId: 'airpair:' + stereoName,
+        name: stereoName + ' - AirPlay Stereo',
+        isStereo: true,
+        devices: arr.map(d => ({ host: d.host, port: d.port, isStereo: true }))
+      });
+    }
+  }
+  return local.concat(air);
+}
+
+// Clamp a volume value to the 0-100 range.
+function clampVolume(value) {
+  return Math.max(0, Math.min(100, value));
+}
+
+module.exports = { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume };

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -3,42 +3,78 @@
  * These tests don't require hardware and test pure logic functions
  */
 
+const { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume } = require('../lib/devices');
+
 describe('BabelPod Utility Functions', () => {
+  describe('parsePcmDevices', () => {
+    const procAsoundPcm = [
+      '00-00: bcm2835 HDMI 1 : bcm2835 HDMI 1 : playback 8',
+      '00-01: bcm2835 Headphones : bcm2835 Headphones : playback 8',
+      '01-00: USB Audio : USB Audio : playback 1 : capture 1',
+      ''
+    ].join('\n');
+
+    test('should parse plughw device IDs from card-device numbers', () => {
+      const { outputs } = parsePcmDevices(procAsoundPcm);
+      expect(outputs.map(d => d.id)).toEqual(['plughw:0,0', 'plughw:0,1', 'plughw:1,0']);
+    });
+
+    test('should split playback and capture devices into outputs and inputs', () => {
+      const { outputs, inputs } = parsePcmDevices(procAsoundPcm);
+      expect(outputs).toHaveLength(3);
+      expect(inputs).toHaveLength(1);
+      expect(inputs[0]).toMatchObject({ id: 'plughw:1,0', name: 'USB Audio' });
+    });
+
+    test('should skip malformed lines', () => {
+      const { outputs, inputs } = parsePcmDevices('not a pcm line\n\n');
+      expect(outputs).toEqual([]);
+      expect(inputs).toEqual([]);
+    });
+  });
+
   describe('buildUnifiedOutputs', () => {
+    const pcmOutputs = [{ id: 'plughw:0,0', name: 'Headphones', output: true, input: false }];
+
     test('should combine local and AirPlay outputs', () => {
-      // This is a placeholder test
-      // In a real implementation, we would extract buildUnifiedOutputs
-      // into a separate module and test it here
-      expect(true).toBe(true);
+      const airplay = [{ name: 'Kitchen', stereo: null, host: '192.168.1.10', port: 7000 }];
+      const unified = buildUnifiedOutputs(pcmOutputs, airplay);
+      expect(unified.map(o => o.uiId)).toEqual(['plughw:0,0', 'air:Kitchen']);
+      expect(unified[0].name).toBe('Headphones - Output');
+      expect(unified[1].name).toBe('Kitchen - AirPlay');
+      expect(unified[1].devices).toEqual([{ host: '192.168.1.10', port: 7000, isStereo: false }]);
     });
 
-    test('should deduplicate AirPlay devices', () => {
-      // Test that duplicate AirPlay devices are unified
-      expect(true).toBe(true);
+    test('should deduplicate AirPlay devices with the same name and host:port', () => {
+      const airplay = [
+        { name: 'Kitchen', stereo: null, host: '192.168.1.10', port: 7000 },
+        { name: 'Kitchen', stereo: null, host: '192.168.1.10', port: 7000 }
+      ];
+      const unified = buildUnifiedOutputs([], airplay);
+      expect(unified).toHaveLength(1);
     });
 
-    test('should group stereo pairs', () => {
-      // Test that stereo pairs are grouped correctly
-      expect(true).toBe(true);
+    test('should group stereo pairs sharing a group name', () => {
+      const airplay = [
+        { name: 'Left HomePod', stereo: 'Living Room', host: '192.168.1.20', port: 7000 },
+        { name: 'Right HomePod', stereo: 'Living Room', host: '192.168.1.21', port: 7000 }
+      ];
+      const unified = buildUnifiedOutputs([], airplay);
+      expect(unified).toHaveLength(1);
+      expect(unified[0]).toMatchObject({
+        uiId: 'airpair:Living Room',
+        name: 'Living Room - AirPlay Stereo',
+        isStereo: true
+      });
+      expect(unified[0].devices).toHaveLength(2);
     });
   });
 
-  describe('Device ID parsing', () => {
-    test('should parse plughw device IDs correctly', () => {
-      // Test device ID parsing from /proc/asound/pcm
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('Session management', () => {
-    test('should handle session owner changes', () => {
-      // Test session owner logic
-      expect(true).toBe(true);
-    });
-
-    test('should prevent non-owners from making changes', () => {
-      // Test permission checks
-      expect(true).toBe(true);
+  describe('clampVolume', () => {
+    test('should clamp out-of-range values to 0-100', () => {
+      expect(clampVolume(150)).toBe(100);
+      expect(clampVolume(-10)).toBe(0);
+      expect(clampVolume(42)).toBe(42);
     });
   });
 
@@ -83,37 +119,38 @@ describe('BabelPod Utility Functions', () => {
     });
   });
 
-  describe('mDNS Service Event Handling', () => {
-    test('should handle AirPlay device regex pattern', () => {
-      // Test the regex pattern for AirPlay service names
-      const fullname = 'Living Room._airplay._tcp.local';
-      const match = /(.*)\._airplay\._tcp\.local/.exec(fullname);
-      expect(match).not.toBeNull();
-      expect(match[1]).toBe('Living Room');
+  describe('parseAirplayService', () => {
+    test('should parse an AirPlay mDNS record', () => {
+      const service = parseAirplayService({
+        fullname: 'Living Room._airplay._tcp.local',
+        addresses: ['192.168.1.100'],
+        port: 7000,
+        txt: {}
+      });
+      expect(service).toEqual({ name: 'Living Room', stereo: null, host: '192.168.1.100', port: 7000 });
     });
 
     test('should extract stereo group name from txt records', () => {
-      // Test extraction of gpn (group name) from mDNS txt records
-      const txt = { gpn: 'Bedroom Stereo Pair' };
-      const stereoName = txt.gpn || null;
-      expect(stereoName).toBe('Bedroom Stereo Pair');
+      const service = parseAirplayService({
+        fullname: 'Bedroom Left._airplay._tcp.local',
+        addresses: ['192.168.1.101'],
+        port: 7000,
+        txt: { gpn: 'Bedroom Stereo Pair' }
+      });
+      expect(service.stereo).toBe('Bedroom Stereo Pair');
     });
 
-    test('should handle device without stereo pairing', () => {
-      // Test that devices without gpn are handled as single devices
-      const txt = {};
-      const stereoName = txt.gpn || null;
-      expect(stereoName).toBeNull();
+    test('should return null for records without a fullname or addresses', () => {
+      expect(parseAirplayService({ addresses: ['192.168.1.1'], port: 7000 })).toBeNull();
+      expect(parseAirplayService({ fullname: 'X._airplay._tcp.local', addresses: [], port: 7000 })).toBeNull();
     });
 
-    test('should track device address and port for updates', () => {
-      // Test that we can identify devices by address:port combination
-      const device = {
-        host: '192.168.1.100',
-        port: 7000
-      };
-      const deviceId = `${device.host}:${device.port}`;
-      expect(deviceId).toBe('192.168.1.100:7000');
+    test('should return null for non-AirPlay services', () => {
+      expect(parseAirplayService({
+        fullname: 'Printer._ipp._tcp.local',
+        addresses: ['192.168.1.50'],
+        port: 631
+      })).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Internal improvements only — no user-facing feature changes.

- **Real unit tests**: `buildUnifiedOutputs`, PCM parsing, and the AirPlay mDNS record parsing were previously "tested" by placeholder `expect(true).toBe(true)` assertions or by re-implementing the logic inside the test file. The pure logic now lives in `lib/devices.js` and the tests exercise the real implementations.
- **Bug fix — PCM device list propagation**: `unifiedOutputs` was only rebuilt by AirPlay mDNS events, so local PCM outputs never appeared in the client list until an unrelated AirPlay event fired, and hot-plugged PCM devices were scanned every 10s but never broadcast. The list is now built at startup and the rescan broadcasts `inputs`/`outputs` when the device set changes.
- **Dedupe**: `serviceUp`/`serviceChanged` handlers were near-identical copies; they now share one upsert that only notifies clients when something actually changed (avoids redundant `outputs` broadcasts on mDNS re-announcements). SIGINT/SIGTERM share one shutdown handler.
- **Hardening**: `setVolume` clamps to 0–100 and rejects NaN/Infinity.

## Testing

- `node -c index.js` passes
- `npm test`: 47 tests pass (placeholders replaced with real assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)