### PR TITLE
Turntable power via Matter smart plug with silence auto-off (API v1.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .nyc_output
 *.log
 babelpod.config.json
+.matter-storage

--- a/API.md
+++ b/API.md
@@ -2,6 +2,8 @@
 
 BabelPod uses [Socket.IO](https://socket.io/) for real-time communication between clients and the server. All payloads are JSON objects. The API version is included in the `state` event on connection.
 
+Additions marked **v1.1** are additive and backward compatible — v1 clients keep working unchanged. New capabilities are signaled by the *presence* of their field in `state` (capability by presence); servers without a feature omit the field entirely and clients hide the corresponding controls.
+
 ## Connection
 
 Connect to the server's Socket.IO endpoint (default `http://<host>:3000`). On connection, the server emits a single `state` event containing the full current state. Subsequent changes are sent as individual events.
@@ -20,9 +22,12 @@ Sent once immediately after connection. Contains the full server state.
   "outputs": [{ "id": "air:Kitchen", "name": "Kitchen (AirPlay)" }, ...],
   "selectedInput": "plughw:0,0",
   "selectedOutputs": ["air:Kitchen", "air:Bedroom"],
-  "volume": 50
+  "volume": 50,
+  "turntablePower": { "on": true, "reachable": true }
 }
 ```
+
+`turntablePower` (v1.1) is present only when the server has a turntable smart plug configured — see [Turntable Power & Silence Auto-Off](#turntable-power--silence-auto-off-v11).
 
 ### `inputs`
 
@@ -63,6 +68,18 @@ Sent when the volume changes.
 ```json
 { "value": 75 }
 ```
+
+### `turntablePower` (v1.1)
+
+Sent on **every** turntable plug state or reachability change — including changes made from Apple Home, the plug's physical button, or the server's silence auto-off — not just in response to `setTurntablePower`. The payload always reflects the real hardware state (the server subscribes to the plug's Matter OnOff attribute and never synthesizes this from a command).
+
+```json
+{ "on": true, "reachable": true }
+```
+
+`reachable: false` means the server currently cannot confirm or command the plug (Matter node offline); `on` is then the last known state and may be stale. Clients should disable their power toggle while unreachable.
+
+Only sent by servers with a configured turntable plug. The `state` event includes the same object as `turntablePower` — its presence is the capability signal for showing the power control.
 
 ### `session`
 
@@ -125,6 +142,16 @@ Set the volume (0-100). Applies to AirPlay outputs.
 { "value": 75 }
 ```
 
+### `setTurntablePower` (v1.1)
+
+Request a turntable plug power change. Requires session ownership. The server does **not** echo this back directly — it commands the plug and lets the Matter OnOff subscription drive the `turntablePower` broadcast, so the confirmation always reflects actual hardware state (and self-corrects if the command failed). Clients should show a pending state rather than flipping their toggle optimistically, and give up after ~8 seconds without a `turntablePower` broadcast.
+
+```json
+{ "on": false }
+```
+
+If the plug is unreachable, the server broadcasts `serverError` plus `turntablePower` with the last known state and `reachable: false`.
+
 ### `takeover`
 
 Claim session ownership. No payload required.
@@ -144,9 +171,14 @@ Update instance configuration. Partial updates allowed — only fields present a
   "defaultOutputIds": ["air:Kitchen", "air:Living Room"],
   "defaultVolume": 50,
   "autoconnectEnabled": true,
-  "autoconnectThreshold": 0.01
+  "autoconnectThreshold": 0.01,
+  "autoOffEnabled": true,
+  "autoOffSilenceThresholdDb": -50,
+  "autoOffSilenceMinutes": 20
 }
 ```
+
+The `autoOff*` fields (v1.1) configure silence auto-off for the turntable plug. The plug itself (`turntablePlugEnabled`, `turntablePlugPairingCode`) can only be configured in `babelpod.config.json` on the server, since commissioning is a one-time operator step that requires a server restart.
 
 ### `setAutoconnect`
 
@@ -221,6 +253,26 @@ The `state` event includes config and autoconnect state:
   "autoconnectState": "idle"
 }
 ```
+
+## Turntable Power & Silence Auto-Off (v1.1)
+
+The turntable can be plugged into a HomeKit-enabled **Matter** smart plug. BabelPod commissions the plug onto its own Matter fabric (multi-admin — it stays paired with Apple Home) and:
+
+- Exposes the plug over the API: `setTurntablePower` / `turntablePower` and `state.turntablePower`.
+- Subscribes to the plug's OnOff attribute, so changes made from Apple Home or the physical button are broadcast to all clients.
+- Optionally powers the plug **off** after sustained input silence (a record left spinning in the runout groove). The silence detector taps the same RMS pipeline as autoconnect, converts to dBFS, and fires only after `autoOffSilenceMinutes` of continuous silence below `autoOffSilenceThresholdDb` — any louder audio resets the window, so inter-track gaps and quiet passages never trigger. After firing it disarms until power returns.
+
+### Setup
+
+1. In Apple Home, open the plug's settings and **Turn On Pairing Mode** to get a fresh setup code (the original code is consumed by Apple Home).
+2. In `babelpod.config.json` set `"turntablePlugEnabled": true` and `"turntablePlugPairingCode": "<code>"`, then restart the server.
+3. Commissioning credentials persist in `.matter-storage/`, so the pairing code is only needed once.
+
+A Wi-Fi Matter plug is reachable directly over IP. A Thread-only plug would additionally require a Thread Border Router on the Pi.
+
+### Ownership and automation
+
+`setTurntablePower` is owner-gated like every other client command. Internal automation (the silence auto-off) uses a privileged path that bypasses the session-owner check without changing session ownership — it never emits `session`, only the resulting `turntablePower`/`status` broadcasts.
 
 ## Session Ownership
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -28,9 +28,19 @@ The Burr-Brown/TI USB Audio CODEC has no ALSA capture volume control — gain is
 - Add an input gain slider to the UI (web + SwiftUI)
 - Consider adding a signal level meter to the UI so users can visually confirm input levels
 
+## Remaining items from the AirSpin server spec (v1.1)
+
+`airspin/docs/babelpod-server-spec.md` (branch `claude/turntable-homekit-volume-LXDRd`) specifies four features. Turntable power (§0/§3: Matter plug + silence auto-off + `turntablePower` events) is implemented. Still open:
+
+- **Per-output volume (§1):** `setOutputVolume {id, value}` / `outputVolume` broadcasts, per-output `volume` field on every output in `state`/`outputs` (capability by presence — must be on *every* output once implemented), `setVolume` becomes "set all", persistence across restarts. `node_airtunes2` already supports per-device volume. AirSpin client side is already implemented.
+- **HTTP command endpoint (§4):** `POST /api/setVolume|setOutputVolume|setTurntablePower` + `GET /api/state` with a shared-secret token, for AirSpin App Intents / Siri Shortcuts. Privileged (bypasses session owner), routes through the same control core, LAN only.
+- **HomeKit volume accessory (§5):** HAP-NodeJS Lightbulb whose `Brightness` maps to volume (the only Siri-controllable numeric), two-way sync, per-output Lightbulbs once §1 lands.
+
 ## iOS App: Push Notification to Turn Off Record Player
 
 When autoconnect transitions from silence to idle (speakers released after 5 minutes of silence), send a push notification from the iOS app reminding the user to turn off the record player. The record is still spinning in the runout groove — the user may have walked away.
+
+*Partially superseded:* the server can now power the turntable off itself after sustained silence via the Matter smart plug (`autoOffEnabled`). A notification remains useful for setups without a smart plug, or as a heads-up that auto-off happened.
 
 Should be gated by a toggle in settings (off by default). Requires the server to emit the silence→idle transition event.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Check logs: `ssh pi@PattyPi.local 'journalctl -u babelpod -f'`
 
 ## Architecture
 
-The server lives in `index.js` (~1100 lines). Pure, hardware-free helpers (PCM device parsing, AirPlay mDNS record parsing, output unification) live in `lib/devices.js` so they can be unit tested directly. The web UI is a single file (`index.html`).
+The server lives in `index.js` (~1300 lines). Pure or hardware-free helpers live in `lib/` so they can be unit tested directly: `lib/devices.js` (PCM device parsing, AirPlay mDNS record parsing, output unification), `lib/turntable.js` (silence auto-off detection), `lib/plugController.js` (Matter smart plug control — matter.js is lazy-loaded inside `start()` so unconfigured servers never pay its memory cost). The web UI is a single file (`index.html`).
 
 ### Audio Pipeline
 
@@ -59,6 +59,10 @@ Documented in `API.md`. Key design points:
 - **Echo detection** — server broadcasts to ALL clients including sender. Clients must track `lastEmitted` values to avoid feedback loops
 - **Event naming:** server-to-client uses nouns (`input`, `output`, `volume`, `session`), client-to-server uses `set`-prefixed verbs (`setInput`, `setOutput`, `setVolume`)
 - **`serverError` not `error`** — `error` is a reserved Socket.IO event name
+
+### Turntable Power (Matter smart plug)
+
+The turntable's power outlet is a Matter smart plug commissioned onto BabelPod's own fabric (multi-admin — it stays paired with Apple Home). Configured via `turntablePlugEnabled`/`turntablePlugPairingCode` in `babelpod.config.json`; credentials persist in `.matter-storage/`. The OnOff attribute subscription drives every `turntablePower` broadcast (never synthesized from commands), so clients always see real hardware state. Silence auto-off (`autoOffEnabled`, threshold in dBFS, duration in minutes) taps the same RMS pipeline as autoconnect and cuts the plug after sustained silence; it is a privileged automation path that bypasses the session-owner lock without changing ownership. See `API.md` § "Turntable Power & Silence Auto-Off".
 
 ### Device Discovery
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ BabelPod is a lightweight Node.js application that captures audio from a selecte
 - Optional PCM device scanning (can be disabled for better performance on systems that don't use ALSA devices).
 - Enhanced mDNS service handling for dynamic IP address changes.
 - Simple UI served by Express + Socket.IO.
+- **Optional:** Turntable power control via a Matter/HomeKit smart plug, with automatic power-off after sustained silence (record left spinning in the runout groove). See `API.md` § "Turntable Power & Silence Auto-Off" for setup.
 
 ## Prerequisites
 

--- a/index.html
+++ b/index.html
@@ -235,6 +235,38 @@
         border-radius: 2px;
       }
 
+      /* Turntable power */
+      .turntable-power-section {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-top: 1rem;
+      }
+      .turntable-power-section .power-status {
+        font-size: 0.8rem;
+        color: #999;
+        margin-left: auto;
+        margin-right: 0.75rem;
+      }
+      .power-button {
+        padding: 0.4rem 1.1rem;
+        border-radius: 16px;
+        border: 1px solid #444;
+        background: #2a2a2a;
+        color: #ddd;
+        font-size: 0.9rem;
+        cursor: pointer;
+      }
+      .power-button.on {
+        background: #2e7d32;
+        border-color: #2e7d32;
+        color: white;
+      }
+      .power-button:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+
       /* Settings section */
       details.settings {
         margin-top: 1rem;
@@ -279,6 +311,13 @@
     <div class="container">
       <label>Input Device</label>
       <div class="radio-list" id="inputsList"></div>
+
+      <!-- Hidden unless the server reports turntablePower (capability by presence) -->
+      <div class="turntable-power-section" id="turntablePowerSection" style="display: none;">
+        <label style="margin: 0;">Turntable Power</label>
+        <span class="power-status" id="turntablePowerStatus"></span>
+        <button class="power-button" id="turntablePowerButton" onclick="toggleTurntablePower()">Off</button>
+      </div>
 
       <label for="outputVolume">Volume</label>
       <div style="display: flex; align-items: center; gap: 8px;">
@@ -378,6 +417,9 @@
       let currentConfig = {};
       let currentAutoconnectState = "paused";
       let availableOutputsList = [];
+      let turntablePower = null; // {on, reachable} — null when the server has no plug
+      let turntablePowerPending = false;
+      let turntablePowerPendingTimeout = null;
 
       const inputsList = document.getElementById("inputsList");
       const volumeRange = document.getElementById("outputVolume");
@@ -522,6 +564,8 @@
         isOwner = (socket.id === s.sessionOwner);
         if (s.config) currentConfig = s.config;
         if (s.autoconnectState) currentAutoconnectState = s.autoconnectState;
+        turntablePower = s.turntablePower || null;
+        renderTurntablePower();
 
         renderInputsList();
         updateInputSelection();
@@ -591,6 +635,15 @@
       socket.on("status", (d) => { showStatus(d.message); });
       socket.on("serverError", (d) => { showError(d.message); });
 
+      // Turntable power — always adopt the broadcast hardware state, never
+      // flip the toggle optimistically
+      socket.on("turntablePower", (d) => {
+        turntablePower = { on: d.on, reachable: d.reachable };
+        turntablePowerPending = false;
+        if (turntablePowerPendingTimeout) clearTimeout(turntablePowerPendingTimeout);
+        renderTurntablePower();
+      });
+
       // Connection lifecycle
       socket.on("connect", () => {
         lastEmittedVolume = null;
@@ -656,6 +709,44 @@
           }
         });
       });
+
+      // Turntable power controls
+      function renderTurntablePower() {
+        const section = document.getElementById("turntablePowerSection");
+        if (!turntablePower) {
+          section.style.display = "none";
+          return;
+        }
+        section.style.display = "flex";
+
+        const button = document.getElementById("turntablePowerButton");
+        const status = document.getElementById("turntablePowerStatus");
+        if (turntablePowerPending) {
+          button.disabled = true;
+          status.textContent = "Updating…";
+          return;
+        }
+        button.disabled = !turntablePower.reachable;
+        button.textContent = turntablePower.on ? "On" : "Off";
+        button.classList.toggle("on", turntablePower.on);
+        status.textContent = turntablePower.reachable ? "" : "Plug unreachable — state may be stale";
+      }
+
+      function toggleTurntablePower() {
+        if (!turntablePower || turntablePowerPending || !turntablePower.reachable) return;
+        socket.emit("setTurntablePower", { on: !turntablePower.on });
+        turntablePowerPending = true;
+        renderTurntablePower();
+        // The server confirms via a turntablePower broadcast; give up after 8s
+        if (turntablePowerPendingTimeout) clearTimeout(turntablePowerPendingTimeout);
+        turntablePowerPendingTimeout = setTimeout(() => {
+          if (turntablePowerPending) {
+            turntablePowerPending = false;
+            renderTurntablePower();
+            showError("No response from turntable plug");
+          }
+        }, 8000);
+      }
 
       // Autoconnect controls
       function toggleAutoconnect() {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ const AirTunes = require('airtunes2');
 const { hostname } = require('os');
 const path = require('path');
 const { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume } = require('./lib/devices');
+const { SilenceAutoOff } = require('./lib/turntable');
+const { MatterPlugController } = require('./lib/plugController');
 
 // =======================
 // 1a) Log level
@@ -46,7 +48,17 @@ const DEFAULT_CONFIG = {
   defaultOutputIds: [],
   defaultVolume: 50,
   autoconnectEnabled: false,
-  autoconnectThreshold: 0.01
+  autoconnectThreshold: 0.01,
+  // Turntable smart plug (Matter). Commission once by putting the plug in
+  // pairing mode from Apple Home and setting the code here; credentials then
+  // persist in .matter-storage and the code is no longer needed.
+  turntablePlugEnabled: false,
+  turntablePlugPairingCode: null,
+  // Silence auto-off: cut the plug after sustained silence (record left
+  // spinning in the runout groove).
+  autoOffEnabled: false,
+  autoOffSilenceThresholdDb: -50,
+  autoOffSilenceMinutes: 20
 };
 
 let config = { ...DEFAULT_CONFIG };
@@ -139,8 +151,9 @@ class RmsMonitorTransform extends stream.Transform {
   _transform(chunk, encoding, callback) {
     lastInputDataTime = Date.now();
 
-    // Skip RMS calculation when autoconnect is paused (save CPU)
-    if (autoconnectState.state === 'paused') {
+    // Skip RMS calculation when nothing consumes it (save CPU): autoconnect
+    // paused and silence auto-off not armed
+    if (autoconnectState.state === 'paused' && !silenceAutoOff.armed) {
       callback(null, chunk);
       return;
     }
@@ -367,11 +380,109 @@ function setAutoconnectState(newState) {
   }
 }
 
-// Hook RMS readings into autoconnect state machine
+// Hook RMS readings into autoconnect state machine and silence auto-off
 function wireRmsMonitor() {
   rmsMonitor.on('rms', tickAutoconnect);
+  rmsMonitor.on('rms', rms => silenceAutoOff.handleRms(rms));
 }
 wireRmsMonitor();
+
+// =======================
+// 4d) Turntable smart plug & silence auto-off
+// =======================
+// The turntable is plugged into a Matter smart plug commissioned onto
+// BabelPod's own fabric (it stays paired with Apple Home — multi-admin).
+// The OnOff attribute subscription reports every hardware state change,
+// including ones made from Apple Home or the plug's physical button, and
+// each one is broadcast to all clients as `turntablePower`.
+let plugController = null;
+
+const silenceAutoOff = new SilenceAutoOff({
+  thresholdDb: config.autoOffSilenceThresholdDb,
+  durationMs: (config.autoOffSilenceMinutes || 20) * 60 * 1000,
+  onTrigger: handleAutoOffTrigger
+});
+
+function buildTurntablePowerPayload() {
+  return { on: plugController.isOn, reachable: plugController.isReachable };
+}
+
+function broadcastTurntablePower() {
+  if (!plugController) return;
+  io.emit('turntablePower', buildTurntablePowerPayload());
+}
+
+// Monitor for silence only when it can lead to an auto-off: feature enabled,
+// a real input selected, and the plug actually on.
+function updateAutoOffArming() {
+  silenceAutoOff.configure({
+    thresholdDb: config.autoOffSilenceThresholdDb,
+    durationMs: (config.autoOffSilenceMinutes || 20) * 60 * 1000
+  });
+  const armed = !!plugController && config.autoOffEnabled &&
+    currentInput !== 'void' && plugController.isOn;
+  silenceAutoOff.setArmed(armed);
+}
+
+function handleAutoOffTrigger() {
+  const minutes = config.autoOffSilenceMinutes || 20;
+  log.info(`[auto-off] ${minutes} min of silence — powering turntable off`);
+  io.emit('status', { message: `Turntable powered off after ${minutes} min of silence` });
+  applyTurntablePower(false);
+}
+
+// Shared control core for turntable power. Socket.IO handlers gate on session
+// ownership before calling this; internal automation (silence auto-off) calls
+// it directly — the privileged channel that bypasses the owner lock without
+// touching session ownership. The resulting `turntablePower` broadcast comes
+// from the OnOff subscription, never synthesized from the command, so clients
+// always see the real hardware state (self-correcting on failed commands).
+function applyTurntablePower(on) {
+  if (!plugController) {
+    io.emit('serverError', { message: 'No turntable plug configured' });
+    return;
+  }
+  if (!plugController.isReachable) {
+    io.emit('serverError', { message: 'Turntable plug is unreachable' });
+    broadcastTurntablePower();
+    return;
+  }
+  plugController.setPower(on).catch(e => {
+    console.error("Error setting turntable plug power:", e);
+    io.emit('serverError', { message: `Turntable plug error: ${e.message}` });
+    broadcastTurntablePower();
+  });
+}
+
+async function startTurntablePlug() {
+  if (!config.turntablePlugEnabled) return;
+
+  plugController = new MatterPlugController({
+    pairingCode: config.turntablePlugPairingCode,
+    storagePath: path.join(__dirname, '.matter-storage'),
+    log
+  });
+
+  plugController.on('change', ({ on, reachable }) => {
+    log.info(`[plug] state changed: on=${on} reachable=${reachable}`);
+    if (on) silenceAutoOff.reset(); // power restored — start a fresh silence window
+    updateAutoOffArming();
+    broadcastTurntablePower();
+  });
+
+  try {
+    await plugController.start();
+    log.info(`[plug] connected: on=${plugController.isOn} reachable=${plugController.isReachable}`);
+    updateAutoOffArming();
+    broadcastTurntablePower();
+  } catch (e) {
+    // Keep the controller so clients see the capability with reachable: false
+    console.error("Turntable plug setup failed:", e.message);
+    io.emit('serverError', { message: `Turntable plug setup failed: ${e.message}` });
+    broadcastTurntablePower();
+  }
+}
+startTurntablePlug();
 
 // =======================
 // 5) Main audio duplicator
@@ -551,7 +662,7 @@ function buildCleanOutputs() {
 }
 
 function buildStatePayload() {
-  return {
+  const state = {
     version: 1,
     sessionOwner,
     inputs: buildCleanInputs(),
@@ -562,6 +673,12 @@ function buildStatePayload() {
     config,
     autoconnectState: autoconnectState.state
   };
+  // Capability signaling: present only when a plug is configured — clients
+  // show the turntable power control based on this field's presence
+  if (plugController) {
+    state.turntablePower = buildTurntablePowerPayload();
+  }
+  return state;
 }
 
 // Emit updates to clients
@@ -910,6 +1027,7 @@ io.on('connection', socket => {
     try {
       cleanupCurrentInput();
       currentInput = devId;
+      updateAutoOffArming();
 
       if (devId === "void") {
         inputGeneration++;
@@ -1003,19 +1121,33 @@ io.on('connection', socket => {
     const oldDisplayName = config.displayName;
 
     // Only allow known fields
-    const allowedFields = ['displayName', 'defaultInputId', 'defaultOutputIds', 'defaultVolume', 'autoconnectEnabled', 'autoconnectThreshold'];
+    const allowedFields = [
+      'displayName', 'defaultInputId', 'defaultOutputIds', 'defaultVolume',
+      'autoconnectEnabled', 'autoconnectThreshold',
+      'autoOffEnabled', 'autoOffSilenceThresholdDb', 'autoOffSilenceMinutes'
+    ];
     const filtered = {};
     for (const key of allowedFields) {
       if (key in data) filtered[key] = data[key];
     }
 
     saveConfig(filtered);
+    updateAutoOffArming();
 
     if (config.displayName !== oldDisplayName) {
       restartAdvertisement();
     }
 
     io.emit('status', { message: 'Settings saved' });
+  });
+
+  socket.on('setTurntablePower', (data) => {
+    const on = data?.on;
+    if (typeof on !== 'boolean') return;
+    if (socket.id !== sessionOwner) return;
+
+    console.log("Setting turntable power:", on);
+    applyTurntablePower(on);
   });
 
   socket.on('setAutoconnect', (data) => {

--- a/lib/plugController.js
+++ b/lib/plugController.js
@@ -1,0 +1,156 @@
+/*
+  Smart plug control for the turntable outlet.
+
+  MatterPlugController commissions a Matter smart plug onto BabelPod's own
+  fabric (multi-admin — the plug stays paired with Apple Home) and exposes a
+  small interface so the mechanism stays swappable:
+
+    await controller.start()         — connect (commission first if needed)
+    await controller.setPower(bool)  — send OnOff On/Off command
+    controller.isOn                  — last reported hardware state
+    controller.isReachable           — node online + subscription healthy
+    controller.on('change', {on, reachable} => ...) — fired on every hardware
+      state or reachability change, including changes made from Apple Home or
+      the plug's physical button (OnOff attribute subscription)
+    await controller.stop()
+
+  matter.js is loaded lazily inside start() so servers without a configured
+  plug never pay its memory cost (important on the Pi Zero's 512MB).
+
+  Commissioning is a one-time operator step: in Apple Home open the plug,
+  "Turn On Pairing Mode" to get a fresh setup code, and put that code in
+  babelpod.config.json as turntablePlugPairingCode. Fabric credentials persist
+  in the storage directory, so the code is only needed once.
+*/
+
+const { EventEmitter } = require('events');
+
+const ONOFF_CLUSTER_ID = 6; // Matter OnOff cluster (0x0006)
+
+class MatterPlugController extends EventEmitter {
+  constructor({ pairingCode = null, storagePath, log = console } = {}) {
+    super();
+    this.pairingCode = pairingCode;
+    this.storagePath = storagePath;
+    this.log = log;
+    this.isOn = false;
+    this.isReachable = false;
+    this.controller = null;
+    this.node = null;
+    this.onOffEndpoint = null;
+    this.OnOffClient = null;
+  }
+
+  updateState({ on, reachable }) {
+    let changed = false;
+    if (typeof on === 'boolean' && on !== this.isOn) {
+      this.isOn = on;
+      changed = true;
+    }
+    if (typeof reachable === 'boolean' && reachable !== this.isReachable) {
+      this.isReachable = reachable;
+      changed = true;
+    }
+    if (changed) this.emit('change', { on: this.isOn, reachable: this.isReachable });
+  }
+
+  async start() {
+    const { Environment } = await import('@matter/main');
+    const { OnOffClient } = await import('@matter/main/behaviors/on-off');
+    const { GeneralCommissioning } = await import('@matter/main/clusters');
+    const { ManualPairingCodeCodec } = await import('@matter/main/types');
+    const { CommissioningController } = await import('@project-chip/matter.js');
+    const { NodeStates } = await import('@project-chip/matter.js/device');
+    this.OnOffClient = OnOffClient;
+
+    const environment = Environment.default;
+    if (this.storagePath) environment.vars.set('storage.path', this.storagePath);
+
+    this.controller = new CommissioningController({
+      environment: { environment, id: 'babelpod-turntable-plug' },
+      autoConnect: false,
+      adminFabricLabel: 'BabelPod'
+    });
+    await this.controller.start();
+
+    if (!this.controller.isCommissioned()) {
+      if (!this.pairingCode) {
+        throw new Error(
+          'Plug is not commissioned. In Apple Home, enable pairing mode on the plug ' +
+          'and set turntablePlugPairingCode in babelpod.config.json.'
+        );
+      }
+      this.log.info('Commissioning Matter plug...');
+      const { shortDiscriminator, passcode } = ManualPairingCodeCodec.decode(this.pairingCode);
+      const nodeId = await this.controller.commissionNode({
+        commissioning: {
+          regulatoryLocation: GeneralCommissioning.RegulatoryLocationType.IndoorOutdoor,
+          regulatoryCountryCode: 'XX'
+        },
+        discovery: {
+          identifierData: { shortDiscriminator },
+          discoveryCapabilities: { ble: false }
+        },
+        passcode
+      });
+      this.log.info(`Matter plug commissioned with nodeId ${nodeId}`);
+    }
+
+    const [nodeId] = this.controller.getCommissionedNodes();
+    if (nodeId === undefined) throw new Error('No commissioned Matter node found');
+    const node = await this.controller.getNode(nodeId);
+    this.node = node;
+
+    // Hardware sync: every OnOff attribute report — including changes made
+    // from Apple Home or the physical button — flows through here.
+    node.events.attributeChanged.on(({ path: { clusterId, attributeName }, value }) => {
+      if (clusterId === ONOFF_CLUSTER_ID && attributeName === 'onOff') {
+        this.updateState({ on: !!value });
+      }
+    });
+    node.events.stateChanged.on(state => {
+      this.updateState({ reachable: state === NodeStates.Connected });
+    });
+
+    if (!node.isConnected) node.connect();
+    if (!node.initialized) await node.events.initialized;
+
+    this.onOffEndpoint = this.findOnOffEndpoint();
+    if (!this.onOffEndpoint) throw new Error('Commissioned Matter node has no OnOff endpoint');
+
+    const initialState = this.onOffEndpoint.stateOf(OnOffClient);
+    this.updateState({ on: !!initialState?.onOff, reachable: node.isConnected });
+  }
+
+  findOnOffEndpoint() {
+    for (const endpoint of this.node.parts) {
+      try {
+        if (endpoint.stateOf(this.OnOffClient) !== undefined) return endpoint;
+      } catch (e) {
+        // endpoint without OnOff support — keep looking
+      }
+    }
+    return null;
+  }
+
+  async setPower(on) {
+    if (!this.onOffEndpoint) throw new Error('Plug is not connected');
+    const commands = this.onOffEndpoint.commandsOf(this.OnOffClient);
+    if (on) {
+      await commands.on();
+    } else {
+      await commands.off();
+    }
+    // Do not update state here — the OnOff attribute subscription reports the
+    // real post-command hardware state, which self-corrects failed commands.
+  }
+
+  async stop() {
+    if (this.controller) await this.controller.close();
+    this.controller = null;
+    this.node = null;
+    this.onOffEndpoint = null;
+  }
+}
+
+module.exports = { MatterPlugController };

--- a/lib/turntable.js
+++ b/lib/turntable.js
@@ -1,0 +1,69 @@
+/*
+  Turntable power helpers: silence detection for auto-off.
+  Pure logic — no Matter or Socket.IO dependencies — so it can be unit tested.
+*/
+
+// Convert a linear RMS level (0.0-1.0) to dBFS. Silence (0) maps to -Infinity.
+function dbfsFromRms(rms) {
+  if (rms <= 0) return -Infinity;
+  return 20 * Math.log10(rms);
+}
+
+/*
+  Tracks sustained silence on the input and fires onTrigger once silence has
+  lasted the configured duration. Loud samples reset the timer, so inter-track
+  gaps and quiet passages never trigger.
+
+  After firing, the detector disarms itself; call reset() to re-arm (the server
+  does this when the plug reports power-on, or when audio resumes).
+*/
+class SilenceAutoOff {
+  constructor({ thresholdDb = -50, durationMs = 20 * 60 * 1000, onTrigger, now = Date.now } = {}) {
+    this.thresholdDb = thresholdDb;
+    this.durationMs = durationMs;
+    this.onTrigger = onTrigger;
+    this.now = now;
+    this.armed = false;
+    this.triggered = false;
+    this.silentSince = null;
+  }
+
+  configure({ thresholdDb, durationMs }) {
+    if (typeof thresholdDb === 'number' && Number.isFinite(thresholdDb)) this.thresholdDb = thresholdDb;
+    if (typeof durationMs === 'number' && Number.isFinite(durationMs) && durationMs > 0) this.durationMs = durationMs;
+  }
+
+  setArmed(armed) {
+    if (this.armed === armed) return;
+    this.armed = armed;
+    this.silentSince = null;
+    if (armed) this.triggered = false;
+  }
+
+  // Clear a previous trigger and start a fresh silence window.
+  reset() {
+    this.triggered = false;
+    this.silentSince = null;
+  }
+
+  handleRms(rms) {
+    if (!this.armed || this.triggered) return;
+
+    const db = dbfsFromRms(rms);
+    if (db >= this.thresholdDb) {
+      this.silentSince = null;
+      return;
+    }
+
+    const now = this.now();
+    if (this.silentSince === null) {
+      this.silentSince = now;
+    } else if (now - this.silentSince >= this.durationMs) {
+      this.triggered = true;
+      this.silentSince = null;
+      if (this.onTrigger) this.onTrigger();
+    }
+  }
+}
+
+module.exports = { dbfsFromRms, SilenceAutoOff };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     ]
   },
   "dependencies": {
+    "@matter/main": "^0.17.2",
+    "@project-chip/matter.js": "^0.17.2",
     "airtunes2": "ciderapp/node_airtunes2#v2.4.9",
     "bluetoothctl": "https://github.com/DerDaku/node-bluetoothctl.git",
     "dnssd2": "^1.0.0",

--- a/tests/turntable.test.js
+++ b/tests/turntable.test.js
@@ -1,0 +1,182 @@
+/**
+ * Tests for turntable power support: silence auto-off detection and
+ * plug controller state/change-event behavior.
+ */
+
+const { dbfsFromRms, SilenceAutoOff } = require('../lib/turntable');
+const { MatterPlugController } = require('../lib/plugController');
+
+describe('dbfsFromRms', () => {
+  test('full scale RMS is 0 dBFS', () => {
+    expect(dbfsFromRms(1.0)).toBeCloseTo(0);
+  });
+
+  test('silence is -Infinity', () => {
+    expect(dbfsFromRms(0)).toBe(-Infinity);
+  });
+
+  test('RMS 0.00316 is about -50 dBFS (the default threshold)', () => {
+    expect(dbfsFromRms(0.00316)).toBeCloseTo(-50, 0);
+  });
+
+  test('RMS 0.1 is -20 dBFS', () => {
+    expect(dbfsFromRms(0.1)).toBeCloseTo(-20);
+  });
+});
+
+describe('SilenceAutoOff', () => {
+  const MINUTE = 60 * 1000;
+  const LOUD = 0.05;     // ~-26 dBFS, well above -50
+  const SILENT = 0.0001; // -80 dBFS, well below -50
+
+  function createDetector({ durationMs = 20 * MINUTE, thresholdDb = -50 } = {}) {
+    let currentTime = 0;
+    const onTrigger = jest.fn();
+    const detector = new SilenceAutoOff({
+      thresholdDb,
+      durationMs,
+      onTrigger,
+      now: () => currentTime
+    });
+    return {
+      detector,
+      onTrigger,
+      advance(ms) { currentTime += ms; }
+    };
+  }
+
+  test('does nothing when not armed', () => {
+    const { detector, onTrigger, advance } = createDetector();
+    detector.handleRms(SILENT);
+    advance(30 * MINUTE);
+    detector.handleRms(SILENT);
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+
+  test('fires after sustained silence reaches the configured duration', () => {
+    const { detector, onTrigger, advance } = createDetector();
+    detector.setArmed(true);
+    detector.handleRms(SILENT); // starts the silence window
+    advance(20 * MINUTE);
+    detector.handleRms(SILENT);
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not fire before the duration elapses', () => {
+    const { detector, onTrigger, advance } = createDetector();
+    detector.setArmed(true);
+    detector.handleRms(SILENT);
+    advance(19 * MINUTE);
+    detector.handleRms(SILENT);
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+
+  test('audio above the threshold resets the silence window (inter-track gaps never trigger)', () => {
+    const { detector, onTrigger, advance } = createDetector();
+    detector.setArmed(true);
+    detector.handleRms(SILENT);
+    advance(15 * MINUTE);
+    detector.handleRms(LOUD); // next track starts
+    advance(10 * MINUTE);
+    detector.handleRms(SILENT); // new window starts here
+    advance(19 * MINUTE);
+    detector.handleRms(SILENT);
+    expect(onTrigger).not.toHaveBeenCalled();
+    advance(1 * MINUTE);
+    detector.handleRms(SILENT);
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  test('fires only once, then stays disarmed until reset', () => {
+    const { detector, onTrigger, advance } = createDetector();
+    detector.setArmed(true);
+    detector.handleRms(SILENT);
+    advance(20 * MINUTE);
+    detector.handleRms(SILENT);
+    advance(40 * MINUTE);
+    detector.handleRms(SILENT);
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+
+    detector.reset(); // power came back
+    detector.handleRms(SILENT);
+    advance(20 * MINUTE);
+    detector.handleRms(SILENT);
+    expect(onTrigger).toHaveBeenCalledTimes(2);
+  });
+
+  test('re-arming clears any accumulated silence', () => {
+    const { detector, onTrigger, advance } = createDetector();
+    detector.setArmed(true);
+    detector.handleRms(SILENT);
+    advance(19 * MINUTE);
+    detector.setArmed(false);
+    detector.setArmed(true);
+    advance(2 * MINUTE);
+    detector.handleRms(SILENT); // fresh window — only now starts counting
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+
+  test('configure updates threshold and duration', () => {
+    const { detector, onTrigger, advance } = createDetector();
+    detector.configure({ thresholdDb: -30, durationMs: 5 * MINUTE });
+    detector.setArmed(true);
+    detector.handleRms(0.01); // -40 dBFS: silent under the new -30 threshold
+    advance(5 * MINUTE);
+    detector.handleRms(0.01);
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  test('configure ignores invalid values', () => {
+    const { detector } = createDetector();
+    detector.configure({ thresholdDb: NaN, durationMs: -5 });
+    expect(detector.thresholdDb).toBe(-50);
+    expect(detector.durationMs).toBe(20 * 60 * 1000);
+  });
+});
+
+describe('MatterPlugController state tracking', () => {
+  test('starts off and unreachable', () => {
+    const controller = new MatterPlugController({ storagePath: '/tmp/unused' });
+    expect(controller.isOn).toBe(false);
+    expect(controller.isReachable).toBe(false);
+  });
+
+  test('emits change with the full {on, reachable} payload when power state changes', () => {
+    const controller = new MatterPlugController({ storagePath: '/tmp/unused' });
+    const changes = [];
+    controller.on('change', payload => changes.push(payload));
+
+    controller.updateState({ reachable: true });
+    controller.updateState({ on: true });
+    expect(changes).toEqual([
+      { on: false, reachable: true },
+      { on: true, reachable: true }
+    ]);
+  });
+
+  test('does not emit change when nothing changed', () => {
+    const controller = new MatterPlugController({ storagePath: '/tmp/unused' });
+    const changes = [];
+    controller.on('change', payload => changes.push(payload));
+
+    controller.updateState({ on: false, reachable: false });
+    expect(changes).toEqual([]);
+  });
+
+  test('reports unreachable transitions (node offline)', () => {
+    const controller = new MatterPlugController({ storagePath: '/tmp/unused' });
+    controller.updateState({ on: true, reachable: true });
+
+    const changes = [];
+    controller.on('change', payload => changes.push(payload));
+    controller.updateState({ reachable: false });
+
+    // Last known power state is preserved while unreachable
+    expect(changes).toEqual([{ on: true, reachable: false }]);
+  });
+
+  test('setPower rejects when not connected', async () => {
+    const controller = new MatterPlugController({ storagePath: '/tmp/unused' });
+    await expect(controller.setPower(true)).rejects.toThrow('not connected');
+  });
+});


### PR DESCRIPTION
## Summary

Implements **§0 (ownership/headless model)** and **§3 (turntable power)** of the AirSpin server spec ([airspin `docs/babelpod-server-spec.md`](https://github.com/nicemohawk/airspin/blob/claude/turntable-homekit-volume-LXDRd/docs/babelpod-server-spec.md)). The remaining spec sections (§1 per-output volume, §4 HTTP endpoint, §5 HomeKit accessory) are recorded in `BACKLOG.md`.

> **Stacked on [#16](https://github.com/benlachman/babelpod/pull/16)** — merge that first; this PR's base is its branch.

### What it does

- **Matter plug control** (`lib/plugController.js`): commissions the plug onto BabelPod's own fabric (multi-admin — stays paired with Apple Home), commands OnOff, and **subscribes to the OnOff attribute** so changes from Apple Home or the physical button reach all clients. Reachability tracked from node connection state. matter.js is lazy-loaded inside `start()` so servers without a plug pay none of its memory cost (Pi Zero, 512MB).
- **Silence auto-off** (`lib/turntable.js`): taps the existing RMS pipeline, converts to dBFS, and cuts the plug after `autoOffSilenceMinutes` of continuous silence below `autoOffSilenceThresholdDb` (defaults −50 dBFS / 20 min). Any louder audio resets the window — inter-track gaps and quiet passages never trigger. Disarms after firing until power returns.
- **API v1.1** (additive): `setTurntablePower {on}` (owner-gated) and `turntablePower {on, reachable}` broadcasts driven **only** by the hardware subscription (never synthesized from commands — self-corrects failed commands). `state.turntablePower` presence is the capability signal. Auto-off runs through a privileged path that bypasses the session-owner lock without changing ownership (spec §0).
- **Web UI parity**: power toggle with the exact client semantics AirSpin implements — never optimistic, "Updating…" pending with 8s timeout, disabled while unreachable.
- **Config** (`babelpod.config.json`): `turntablePlugEnabled`, `turntablePlugPairingCode` (file-only, one-time commissioning), `autoOffEnabled`, `autoOffSilenceThresholdDb`, `autoOffSilenceMinutes` (also settable via `setConfig`).

### Setup (one-time)

Apple Home → plug → Turn On Pairing Mode → put the fresh code in `babelpod.config.json` → restart. Credentials persist in `.matter-storage/`. Wi-Fi plugs work directly over IP; Thread-only plugs would need a border router on the Pi.

## Testing

- `npm test`: 64 tests pass, including new suites for silence-detection timing (injected clock) and plug state/change-event contract
- `node -c index.js` passes
- Smoke-tested over Socket.IO polling: `state.turntablePower` is **absent** with the plug disabled, **present** (`{on:false, reachable:false}`) when enabled-but-uncommissioned, and the server survives failed plug setup with a helpful commissioning hint in the log
- Verified all matter.js 0.17.2 imports resolve and `ManualPairingCodeCodec` decodes the standard test pairing code
- **Not tested against real plug hardware** — commissioning + OnOff subscription need a live Matter plug on the Pi's LAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)