### PR TITLE
Fix OnOff endpoint discovery racing remote structure read

### DIFF
--- a/lib/plugController.js
+++ b/lib/plugController.js
@@ -30,7 +30,9 @@ const ONOFF_CLUSTER_ID = 6; // Matter OnOff cluster (0x0006)
 class MatterPlugController extends EventEmitter {
   constructor({ pairingCode = null, storagePath, log = console } = {}) {
     super();
-    this.pairingCode = pairingCode;
+    // Apple Home shows pairing codes with dashes (XXXX-XXX-XXXX); the Matter
+    // codec wants digits only
+    this.pairingCode = pairingCode ? String(pairingCode).replace(/\D/g, '') : null;
     this.storagePath = storagePath;
     this.log = log;
     this.isOn = false;
@@ -115,11 +117,34 @@ class MatterPlugController extends EventEmitter {
     if (!node.isConnected) node.connect();
     if (!node.initialized) await node.events.initialized;
 
-    this.onOffEndpoint = this.findOnOffEndpoint();
-    if (!this.onOffEndpoint) throw new Error('Commissioned Matter node has no OnOff endpoint');
+    // `initialized` can fire from the local cache before the remote device
+    // structure has been read (fresh commissioning, cold cache), leaving
+    // node.parts empty — wait for the structure if the endpoint isn't there yet.
+    this.onOffEndpoint = this.findOnOffEndpoint() || await this.waitForOnOffEndpoint();
 
     const initialState = this.onOffEndpoint.stateOf(OnOffClient);
     this.updateState({ on: !!initialState?.onOff, reachable: node.isConnected });
+  }
+
+  waitForOnOffEndpoint(timeoutMs = 60000) {
+    return new Promise((resolve, reject) => {
+      const check = () => {
+        const endpoint = this.findOnOffEndpoint();
+        if (!endpoint) return;
+        cleanup();
+        resolve(endpoint);
+      };
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(new Error('Commissioned Matter node has no OnOff endpoint (timed out waiting for device structure)'));
+      }, timeoutMs);
+      const cleanup = () => {
+        clearTimeout(timer);
+        this.node.events.structureChanged.off(check);
+      };
+      this.node.events.structureChanged.on(check);
+      check();
+    });
   }
 
   findOnOffEndpoint() {

--- a/tests/turntable.test.js
+++ b/tests/turntable.test.js
@@ -179,4 +179,69 @@ describe('MatterPlugController state tracking', () => {
     const controller = new MatterPlugController({ storagePath: '/tmp/unused' });
     await expect(controller.setPower(true)).rejects.toThrow('not connected');
   });
+
+  test('strips dashes from Apple Home pairing codes', () => {
+    const controller = new MatterPlugController({ pairingCode: '1406-013-3112', storagePath: '/tmp/unused' });
+    expect(controller.pairingCode).toBe('14060133112');
+  });
+});
+
+describe('MatterPlugController endpoint discovery', () => {
+  // Fake matter.js node: parts list mutable, structureChanged observable
+  function createFakeNode(parts = []) {
+    const listeners = new Set();
+    return {
+      parts,
+      events: {
+        structureChanged: {
+          on: fn => listeners.add(fn),
+          off: fn => listeners.delete(fn)
+        }
+      },
+      fireStructureChanged() { listeners.forEach(fn => fn()); },
+      listenerCount: () => listeners.size
+    };
+  }
+
+  function createController(node) {
+    const controller = new MatterPlugController({ storagePath: '/tmp/unused' });
+    controller.node = node;
+    controller.OnOffClient = class FakeOnOffClient {};
+    return controller;
+  }
+
+  const onOffEndpoint = { stateOf: () => ({ onOff: true }) };
+  const otherEndpoint = { stateOf: () => undefined };
+
+  test('resolves when the endpoint appears after a structure change', async () => {
+    const node = createFakeNode([otherEndpoint]);
+    const controller = createController(node);
+
+    const pending = controller.waitForOnOffEndpoint(1000);
+    node.parts.push(onOffEndpoint);
+    node.fireStructureChanged();
+
+    await expect(pending).resolves.toBe(onOffEndpoint);
+    expect(node.listenerCount()).toBe(0); // listener cleaned up
+  });
+
+  test('resolves immediately when the endpoint already exists', async () => {
+    const node = createFakeNode([onOffEndpoint]);
+    const controller = createController(node);
+    await expect(controller.waitForOnOffEndpoint(1000)).resolves.toBe(onOffEndpoint);
+  });
+
+  test('rejects after the timeout when no endpoint appears', async () => {
+    const node = createFakeNode([otherEndpoint]);
+    const controller = createController(node);
+    await expect(controller.waitForOnOffEndpoint(50)).rejects.toThrow('timed out waiting for device structure');
+    expect(node.listenerCount()).toBe(0);
+  });
+
+  test('skips endpoints whose stateOf throws', () => {
+    const throwing = { stateOf: () => { throw new Error('unsupported behavior'); } };
+    const node = createFakeNode([throwing, onOffEndpoint]);
+    const controller = createController(node);
+    expect(controller.findOnOffEndpoint()).toBe(onOffEndpoint);
+  });
 });


### PR DESCRIPTION
## Summary

First real-hardware commissioning (today, on PattyPi) succeeded at the Matter layer but `start()` then failed with **"Commissioned Matter node has no OnOff endpoint"**: with `autoConnect: false`, `node.events.initialized` fires from the local cache before the remote device structure has been read, so `node.parts` is empty right after fresh commissioning.

- `waitForOnOffEndpoint()` listens on `structureChanged` (60s timeout) when the endpoint isn't immediately present, with listener/timer cleanup on both paths.
- Pairing codes are normalized to digits (Apple Home displays `XXXX-XXX-XXXX`).

## Testing

- `npm test`: 88 tests pass, including 4 new ones covering late endpoint appearance, immediate resolution, timeout rejection + listener cleanup, and skipping endpoints whose `stateOf` throws
- Verified on the Pi against the real commissioned plug (see PR comments / deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)