### PR TITLE
Fix OnOff control to use the released matter.js ClusterClient API

### DIFF
--- a/lib/plugController.js
+++ b/lib/plugController.js
@@ -39,8 +39,8 @@ class MatterPlugController extends EventEmitter {
     this.isReachable = false;
     this.controller = null;
     this.node = null;
-    this.onOffEndpoint = null;
-    this.OnOffClient = null;
+    this.onOffClient = null;
+    this.OnOffCluster = null;
   }
 
   updateState({ on, reachable }) {
@@ -58,12 +58,11 @@ class MatterPlugController extends EventEmitter {
 
   async start() {
     const { Environment } = await import('@matter/main');
-    const { OnOffClient } = await import('@matter/main/behaviors/on-off');
-    const { GeneralCommissioning } = await import('@matter/main/clusters');
+    const { GeneralCommissioning, OnOff } = await import('@matter/main/clusters');
     const { ManualPairingCodeCodec } = await import('@matter/main/types');
     const { CommissioningController } = await import('@project-chip/matter.js');
     const { NodeStates } = await import('@project-chip/matter.js/device');
-    this.OnOffClient = OnOffClient;
+    this.OnOffCluster = OnOff.Complete;
 
     const environment = Environment.default;
     if (this.storagePath) environment.vars.set('storage.path', this.storagePath);
@@ -118,25 +117,25 @@ class MatterPlugController extends EventEmitter {
     if (!node.initialized) await node.events.initialized;
 
     // `initialized` can fire from the local cache before the remote device
-    // structure has been read (fresh commissioning, cold cache), leaving
-    // node.parts empty — wait for the structure if the endpoint isn't there yet.
-    this.onOffEndpoint = this.findOnOffEndpoint() || await this.waitForOnOffEndpoint();
+    // structure has been read (fresh commissioning, cold cache), leaving the
+    // device list empty — wait for the structure if the client isn't there yet.
+    this.onOffClient = this.findOnOffClient() || await this.waitForOnOffClient();
 
-    const initialState = this.onOffEndpoint.stateOf(OnOffClient);
-    this.updateState({ on: !!initialState?.onOff, reachable: node.isConnected });
+    const initialOn = await this.onOffClient.getOnOffAttribute();
+    this.updateState({ on: !!initialOn, reachable: node.isConnected });
   }
 
-  waitForOnOffEndpoint(timeoutMs = 60000) {
+  waitForOnOffClient(timeoutMs = 60000) {
     return new Promise((resolve, reject) => {
       const check = () => {
-        const endpoint = this.findOnOffEndpoint();
-        if (!endpoint) return;
+        const client = this.findOnOffClient();
+        if (!client) return;
         cleanup();
-        resolve(endpoint);
+        resolve(client);
       };
       const timer = setTimeout(() => {
         cleanup();
-        reject(new Error('Commissioned Matter node has no OnOff endpoint (timed out waiting for device structure)'));
+        reject(new Error('Commissioned Matter node has no OnOff cluster (timed out waiting for device structure)'));
       }, timeoutMs);
       const cleanup = () => {
         clearTimeout(timer);
@@ -147,24 +146,24 @@ class MatterPlugController extends EventEmitter {
     });
   }
 
-  findOnOffEndpoint() {
-    for (const endpoint of this.node.parts) {
+  findOnOffClient() {
+    for (const device of this.node.getDevices()) {
       try {
-        if (endpoint.stateOf(this.OnOffClient) !== undefined) return endpoint;
+        const client = device.getClusterClient(this.OnOffCluster);
+        if (client !== undefined) return client;
       } catch (e) {
-        // endpoint without OnOff support — keep looking
+        // device without OnOff support — keep looking
       }
     }
     return null;
   }
 
   async setPower(on) {
-    if (!this.onOffEndpoint) throw new Error('Plug is not connected');
-    const commands = this.onOffEndpoint.commandsOf(this.OnOffClient);
+    if (!this.onOffClient) throw new Error('Plug is not connected');
     if (on) {
-      await commands.on();
+      await this.onOffClient.on();
     } else {
-      await commands.off();
+      await this.onOffClient.off();
     }
     // Do not update state here — the OnOff attribute subscription reports the
     // real post-command hardware state, which self-corrects failed commands.
@@ -174,7 +173,7 @@ class MatterPlugController extends EventEmitter {
     if (this.controller) await this.controller.close();
     this.controller = null;
     this.node = null;
-    this.onOffEndpoint = null;
+    this.onOffClient = null;
   }
 }
 

--- a/tests/turntable.test.js
+++ b/tests/turntable.test.js
@@ -186,12 +186,13 @@ describe('MatterPlugController state tracking', () => {
   });
 });
 
-describe('MatterPlugController endpoint discovery', () => {
-  // Fake matter.js node: parts list mutable, structureChanged observable
-  function createFakeNode(parts = []) {
+describe('MatterPlugController OnOff cluster discovery', () => {
+  // Fake matter.js PairedNode: mutable device list, structureChanged observable
+  function createFakeNode(devices = []) {
     const listeners = new Set();
     return {
-      parts,
+      getDevices: () => devices,
+      devices,
       events: {
         structureChanged: {
           on: fn => listeners.add(fn),
@@ -206,42 +207,53 @@ describe('MatterPlugController endpoint discovery', () => {
   function createController(node) {
     const controller = new MatterPlugController({ storagePath: '/tmp/unused' });
     controller.node = node;
-    controller.OnOffClient = class FakeOnOffClient {};
+    controller.OnOffCluster = { id: 6 };
     return controller;
   }
 
-  const onOffEndpoint = { stateOf: () => ({ onOff: true }) };
-  const otherEndpoint = { stateOf: () => undefined };
+  const fakeOnOffClient = { on: async () => {}, off: async () => {}, getOnOffAttribute: async () => true };
+  const onOffDevice = { getClusterClient: () => fakeOnOffClient };
+  const otherDevice = { getClusterClient: () => undefined };
 
-  test('resolves when the endpoint appears after a structure change', async () => {
-    const node = createFakeNode([otherEndpoint]);
+  test('resolves when the OnOff cluster appears after a structure change', async () => {
+    const node = createFakeNode([otherDevice]);
     const controller = createController(node);
 
-    const pending = controller.waitForOnOffEndpoint(1000);
-    node.parts.push(onOffEndpoint);
+    const pending = controller.waitForOnOffClient(1000);
+    node.devices.push(onOffDevice);
     node.fireStructureChanged();
 
-    await expect(pending).resolves.toBe(onOffEndpoint);
+    await expect(pending).resolves.toBe(fakeOnOffClient);
     expect(node.listenerCount()).toBe(0); // listener cleaned up
   });
 
-  test('resolves immediately when the endpoint already exists', async () => {
-    const node = createFakeNode([onOffEndpoint]);
+  test('resolves immediately when the cluster already exists', async () => {
+    const node = createFakeNode([onOffDevice]);
     const controller = createController(node);
-    await expect(controller.waitForOnOffEndpoint(1000)).resolves.toBe(onOffEndpoint);
+    await expect(controller.waitForOnOffClient(1000)).resolves.toBe(fakeOnOffClient);
   });
 
-  test('rejects after the timeout when no endpoint appears', async () => {
-    const node = createFakeNode([otherEndpoint]);
+  test('rejects after the timeout when no OnOff cluster appears', async () => {
+    const node = createFakeNode([otherDevice]);
     const controller = createController(node);
-    await expect(controller.waitForOnOffEndpoint(50)).rejects.toThrow('timed out waiting for device structure');
+    await expect(controller.waitForOnOffClient(50)).rejects.toThrow('timed out waiting for device structure');
     expect(node.listenerCount()).toBe(0);
   });
 
-  test('skips endpoints whose stateOf throws', () => {
-    const throwing = { stateOf: () => { throw new Error('unsupported behavior'); } };
-    const node = createFakeNode([throwing, onOffEndpoint]);
+  test('skips devices whose getClusterClient throws', () => {
+    const throwing = { getClusterClient: () => { throw new Error('unsupported'); } };
+    const node = createFakeNode([throwing, onOffDevice]);
     const controller = createController(node);
-    expect(controller.findOnOffEndpoint()).toBe(onOffEndpoint);
+    expect(controller.findOnOffClient()).toBe(fakeOnOffClient);
+  });
+
+  test('setPower drives the cluster client commands', async () => {
+    const calls = [];
+    const client = { on: async () => calls.push('on'), off: async () => calls.push('off') };
+    const controller = createController(createFakeNode());
+    controller.onOffClient = client;
+    await controller.setPower(true);
+    await controller.setPower(false);
+    expect(calls).toEqual(['on', 'off']);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to [#19](https://github.com/benlachman/babelpod/pull/19). First hardware commissioning succeeded, but OnOff endpoint discovery still timed out: the `endpoint.stateOf()/commandsOf()` API used in `lib/plugController.js` is from the matter.js **main branch** examples — in released **0.17.2**, `PairedNode.getDevices()` returns legacy `Endpoint` objects that expose `getClusterClient(OnOff.Complete)` instead. The `TypeError` was swallowed by the per-endpoint catch, so discovery always came up empty.

- Discovery now iterates `getDevices()` and matches via `getClusterClient(OnOff.Complete)`
- Commands go through the cluster client (`client.on()` / `client.off()`), initial state via `getOnOffAttribute()`
- Same structure-wait/timeout behavior as #19, same hardware-subscription-drives-broadcasts contract

## Testing

- `npm test`: 89 tests pass (discovery fakes updated to the real API shape, plus a setPower command-dispatch test)
- **Verified against the real commissioned plug on PattyPi** via a diagnostic run: initial read `false` → `on()` → read `true` → `off()` → read `false`, with the `attributeChanged` subscription firing on the transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)