### PR TITLE
Raise default auto-off silence threshold to −43 dBFS

### DIFF
--- a/API.md
+++ b/API.md
@@ -173,13 +173,13 @@ Update instance configuration. Partial updates allowed — only fields present a
   "autoconnectEnabled": true,
   "autoconnectThreshold": 0.01,
   "autoOffEnabled": true,
-  "autoOffSilenceThresholdDb": -50,
+  "autoOffSilenceThresholdDb": -43,
   "autoOffNoiseFloorDb": -62,
   "autoOffSilenceMinutes": 20
 }
 ```
 
-The `autoOff*` fields (v1.1) configure silence auto-off for the turntable plug. The plug itself (`turntablePlugEnabled`, `turntablePlugPairingCode`) can only be configured in `babelpod.config.json` on the server, since commissioning is a one-time operator step that requires a server restart.
+The `autoOff*` fields (v1.1) configure silence auto-off for the turntable plug. To calibrate: watch `rmsLevel` (20·log10(level) = dBFS) with the turntable off to find the line's noise floor, and again with a record spinning in the runout groove to find the surface-noise level. Set `autoOffNoiseFloorDb` a few dB above the former and `autoOffSilenceThresholdDb` ~5 dB above the latter — runout noise must land *between* the two or auto-off will never fire (music is far louder, typically −30 dBFS and up, so the threshold has plenty of headroom). The plug itself (`turntablePlugEnabled`, `turntablePlugPairingCode`) can only be configured in `babelpod.config.json` on the server, since commissioning is a one-time operator step that requires a server restart.
 
 ### `setAutoconnect`
 

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ const DEFAULT_CONFIG = {
   // the threshold count as that kind of silence — a line below the noise
   // floor means the turntable itself is already off, and the plug is left on.
   autoOffEnabled: false,
-  autoOffSilenceThresholdDb: -50,
+  autoOffSilenceThresholdDb: -43,
   autoOffNoiseFloorDb: -62,
   autoOffSilenceMinutes: 20
 };

--- a/lib/turntable.js
+++ b/lib/turntable.js
@@ -21,7 +21,8 @@ function dbfsFromRms(rms) {
   surface noise from a powered turntable. A level below the noise floor means
   there is no source at all — the turntable is already off — and cutting the
   outlet would only be an annoyance (measured on PattyPi: turntable-off line
-  noise is -62..-71 dBFS, runout surface noise -54..-60 dBFS).
+  noise is -62..-71 dBFS, runout surface noise smooths to -48..-50 dBFS, so
+  the threshold must sit above that or the window resets forever).
 
   Levels are smoothed with a ~1s EMA before classification so momentary dips
   across either boundary don't reset an otherwise-accumulating window.
@@ -31,7 +32,7 @@ function dbfsFromRms(rms) {
 */
 class SilenceAutoOff {
   constructor({
-    thresholdDb = -50,
+    thresholdDb = -43,
     noiseFloorDb = -62,
     durationMs = 20 * 60 * 1000,
     smoothingAlpha = 0.15,

--- a/tests/turntable.test.js
+++ b/tests/turntable.test.js
@@ -15,7 +15,7 @@ describe('dbfsFromRms', () => {
     expect(dbfsFromRms(0)).toBe(-Infinity);
   });
 
-  test('RMS 0.00316 is about -50 dBFS (the default threshold)', () => {
+  test('RMS 0.00316 is about -50 dBFS', () => {
     expect(dbfsFromRms(0.00316)).toBeCloseTo(-50, 0);
   });
 


### PR DESCRIPTION
## Summary

Live runout-groove test on PattyPi: surface noise smooths to **−48..−50 dBFS**, sitting right at/above the old **−50** default threshold — the silence window reset continuously and auto-off never fired (35 minutes of spinning, zero triggers). Music is at −30 and louder, so −43 keeps ~5 dB margin above this record's noise and 13 dB below music.

- Default `autoOffSilenceThresholdDb`: −50 → **−43** (index.js config default + lib constructor default)
- API.md: calibration guidance — measure the line via `rmsLevel` with the turntable off (sets the noise floor) and in the runout groove (sets the threshold ~5 dB above); runout noise must land between the two
- PattyPi already runs −43 via explicit config (applied live with Ben's approval); this aligns the default for fresh installs

## Testing

- `npm test`: 93 tests pass
- The −43 value is currently being validated live on hardware (record spinning in runout groove, monitor armed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)