### PR TITLE
Master volume follows Apple's group model (preserve speaker balance)

### DIFF
--- a/API.md
+++ b/API.md
@@ -148,7 +148,7 @@ Output ID prefixes:
 
 ### `setVolume`
 
-Set the master volume (0-100). Requires session ownership. Acts as "set all": applies the value to every currently selected AirPlay output's per-output volume, emitting `volume` plus one `outputVolume` per affected output.
+Set the master (group) volume (0-100). Requires session ownership. Follows Apple's group-volume model: the master is the *average* of the selected speakers, and changing it shifts every selected speaker by the same delta, **preserving the relative balance** between them (rather than flattening them to one number). Emits `volume` plus one `outputVolume` per affected speaker. See [Per-Output Volume](#per-output-volume-v11).
 
 ```json
 { "value": 75 }
@@ -281,8 +281,9 @@ Each output can carry its own volume independent of the master. The contract is 
 
 - **Capability by presence.** Every output object in `state.outputs` and the `outputs` event may include an optional integer `volume` (0–100). Clients enable per-speaker control based on the *presence* of this field on any output; a server without the feature omits it entirely and clients fall back to the single master slider.
 - **Which outputs support it.** Only AirPlay outputs (`air:` / `airpair:`) have a software gain knob (via `node_airtunes2` per-device volume), so only they carry `volume`. Local ALSA (`plughw:`) outputs are piped raw to `aplay` with no gain control and omit the field.
-- **Per-output volume is the authoritative device gain** (an absolute 0–100 level, not a trim). The master `volume` / `setVolume` is a "set all" convenience: it overwrites every selected output's per-output volume and emits an `outputVolume` for each. A newly selected output starts at the current master volume.
-- **Events:** `setOutputVolume {id, value}` (client→server, owner-only, clamped/rounded, unknown ids ignored) → applies the gain and broadcasts `outputVolume {id, value}` to all clients.
+- **Per-output volume is the authoritative device gain** (an absolute 0–100 level). `setOutputVolume {id, value}` sets one speaker directly.
+- **Master volume follows Apple's group model.** `state.volume` is the *average* of the selected speakers' per-output volumes. `setVolume` shifts every selected speaker by the same delta to reach the requested average, **preserving their relative balance** — so a speaker you set quieter stays proportionally quieter (60 on a stereo pair and 45 on a mini hold their offset when you move the group). When all speakers are equal this is identical to "set all"; balance is only preserved once you've trimmed speakers apart. At the 0/100 rails a clamped speaker's offset compresses (the additive model can't preserve an offset past a rail). Changing one speaker via `setOutputVolume` likewise re-broadcasts `volume` with the new average, and a newly selected speaker joins at the current group level.
+- **Events:** `setOutputVolume {id, value}` (client→server, owner-only, clamped/rounded, unknown ids ignored) → applies the gain and broadcasts `outputVolume {id, value}` to all clients. `setVolume` broadcasts `volume` plus one `outputVolume` per shifted speaker.
 - **Persistence.** Per-output volumes are runtime state, like the master `volume` — they survive reconnects (re-read from `state`) but reset on server restart. (This is deliberate: persisting every slider movement to `babelpod.config.json` would hammer the Pi's SD card. The master volume behaves the same way.)
 
 ## Turntable Power & Silence Auto-Off (v1.1)

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const dnssd = require('dnssd2');
 const AirTunes = require('airtunes2');
 const { hostname } = require('os');
 const path = require('path');
-const { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume, outputSupportsVolume } = require('./lib/devices');
+const { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume, outputSupportsVolume, averageVolume, applyGroupVolume } = require('./lib/devices');
 const { SilenceAutoOff } = require('./lib/turntable');
 const { MatterPlugController } = require('./lib/plugController');
 
@@ -239,6 +239,14 @@ function activateDefaultOutputs() {
   if (validOutputIds.length > 0) {
     syncOutputs(validOutputIds);
     io.emit('output', { ids: validOutputIds });
+    // Fresh autoconnect brings every speaker up at the default level (overriding
+    // any remembered per-output trims), so the group starts balanced
+    validOutputIds.forEach(uiId => {
+      if (!outputSupportsVolume(uiId)) return;
+      outputVolumes[uiId] = volume;
+      applyOutputVolume(uiId);
+      io.emit('outputVolume', { id: uiId, value: volume });
+    });
     io.emit('volume', { value: volume });
     const missing = config.defaultOutputIds.length - validOutputIds.length;
     const message = missing > 0
@@ -659,6 +667,16 @@ function getOutputVolume(uiId) {
   return Math.round(outputVolumes[uiId] ?? volume);
 }
 
+// The master/group volume is the average of the selected outputs that support
+// per-output volume (Apple's group-volume model). With nothing selected it
+// falls back to the remembered `volume` level (used as the seed for newly
+// selected outputs and reported in state).
+function computeGroupVolume() {
+  const members = selectedOutputs.filter(outputSupportsVolume);
+  if (!members.length) return Math.round(volume);
+  return Math.round(averageVolume(members.map(getOutputVolume)));
+}
+
 // Push an output's stored volume to its underlying AirPlay device(s). Only
 // touches devices currently added to airtunes; the stored value still applies
 // when the output is (re)selected later via syncOutputs.
@@ -722,7 +740,7 @@ function buildStatePayload() {
     outputs: buildCleanOutputs(),
     selectedInput: currentInput,
     selectedOutputs,
-    volume,
+    volume: computeGroupVolume(),
     config,
     autoconnectState: autoconnectState.state
   };
@@ -1171,6 +1189,9 @@ io.on('connection', socket => {
     try {
       syncOutputs(outs);
       io.emit('output', { ids: outs });
+      // Selection changed the group membership — refresh the master (group average)
+      volume = computeGroupVolume();
+      io.emit('volume', { value: volume });
       io.emit('status', { message: `Outputs updated` });
     } catch (e) {
       console.error("Error switching output:", e);
@@ -1185,17 +1206,24 @@ io.on('connection', socket => {
 
     if (socket.id !== sessionOwner) return;
     try {
-      volume = Math.round(clampVolume(vol));
+      const target = Math.round(clampVolume(vol));
+      // Apple-style group volume: shift every selected per-output speaker by the
+      // delta needed to move the group average to `target`, preserving the
+      // relative balance between speakers (rather than flattening them all to
+      // the same number). Each shifted speaker broadcasts its new outputVolume.
+      const members = selectedOutputs.filter(outputSupportsVolume);
+      if (members.length) {
+        const shifted = applyGroupVolume(members.map(getOutputVolume), target);
+        members.forEach((uiId, i) => {
+          outputVolumes[uiId] = shifted[i];
+          applyOutputVolume(uiId);
+          io.emit('outputVolume', { id: uiId, value: shifted[i] });
+        });
+        volume = computeGroupVolume(); // true group average after any rail clamping
+      } else {
+        volume = target; // no per-output speakers — just remember the level
+      }
       io.emit('volume', { value: volume });
-      // "Set all": master volume applies to every selected output's per-output
-      // volume, updating each stored value and broadcasting it so per-speaker
-      // sliders stay in sync. Per-output volume is the authoritative device gain.
-      selectedOutputs.forEach(uiId => {
-        if (!outputSupportsVolume(uiId)) return;
-        outputVolumes[uiId] = volume;
-        applyOutputVolume(uiId);
-        io.emit('outputVolume', { id: uiId, value: volume });
-      });
     } catch (e) {
       console.error("Error changing volume:", e);
       io.emit('serverError', { message: `Failed to change volume: ${e.message}` });
@@ -1216,6 +1244,11 @@ io.on('connection', socket => {
       outputVolumes[id] = value;
       applyOutputVolume(id);
       io.emit('outputVolume', { id, value });
+      // Changing one speaker moves the group average — keep master in sync
+      if (selectedOutputs.includes(id)) {
+        volume = computeGroupVolume();
+        io.emit('volume', { value: volume });
+      }
     } catch (e) {
       console.error("Error changing output volume:", e);
       io.emit('serverError', { message: `Failed to change output volume: ${e.message}` });

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -103,4 +103,34 @@ function outputSupportsVolume(uiId) {
   return typeof uiId === 'string' && (uiId.startsWith('air:') || uiId.startsWith('airpair:'));
 }
 
-module.exports = { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume, outputSupportsVolume };
+// Average of a list of volumes (0 for an empty list).
+function averageVolume(values) {
+  if (!values.length) return 0;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+// Apple-style group (master) volume. The group level is the average of its
+// members; moving it shifts every member by the same delta needed to reach
+// `target`, preserving the relative balance between speakers (a speaker set
+// quieter stays proportionally quieter). Members clamp at 0-100. Returns new
+// integer volumes in the same order as the input.
+//
+// When all members are equal this is identical to "set all"; balance is only
+// preserved once individual speakers have been trimmed apart. Note: when a
+// member clamps at a rail its offset is compressed (the additive model can't
+// preserve an offset past 0/100).
+function applyGroupVolume(values, target) {
+  if (!values.length) return [];
+  const delta = clampVolume(target) - averageVolume(values);
+  return values.map(v => Math.round(clampVolume(v + delta)));
+}
+
+module.exports = {
+  parsePcmDevices,
+  parseAirplayService,
+  buildUnifiedOutputs,
+  clampVolume,
+  outputSupportsVolume,
+  averageVolume,
+  applyGroupVolume
+};

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -3,7 +3,7 @@
  * These tests don't require hardware and test pure logic functions
  */
 
-const { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume, outputSupportsVolume } = require('../lib/devices');
+const { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume, outputSupportsVolume, averageVolume, applyGroupVolume } = require('../lib/devices');
 
 describe('BabelPod Utility Functions', () => {
   describe('parsePcmDevices', () => {
@@ -100,6 +100,43 @@ describe('BabelPod Utility Functions', () => {
     test('handles non-string input safely', () => {
       expect(outputSupportsVolume(undefined)).toBe(false);
       expect(outputSupportsVolume(null)).toBe(false);
+    });
+  });
+
+  describe('averageVolume', () => {
+    test('averages a list, 0 for empty', () => {
+      expect(averageVolume([])).toBe(0);
+      expect(averageVolume([40, 60])).toBe(50);
+      expect(averageVolume([30, 50, 70])).toBe(50);
+    });
+  });
+
+  describe('applyGroupVolume (Apple-style master)', () => {
+    test('equal members behave like "set all"', () => {
+      expect(applyGroupVolume([50, 50], 70)).toEqual([70, 70]);
+    });
+
+    test('preserves the relative balance between speakers', () => {
+      // average 40 → target 60 shifts both up by 20, keeping the 20-point gap
+      expect(applyGroupVolume([30, 50], 60)).toEqual([50, 70]);
+    });
+
+    test('is a no-op when target equals the current average', () => {
+      expect(applyGroupVolume([30, 50], 40)).toEqual([30, 50]);
+    });
+
+    test('clamps members at the rails (offset compresses past 0/100)', () => {
+      expect(applyGroupVolume([30, 50], 0)).toEqual([0, 10]);
+      expect(applyGroupVolume([30, 50], 100)).toEqual([90, 100]);
+    });
+
+    test('rounds to integers', () => {
+      // average 41.67 → target 50 shifts by ~8.33
+      expect(applyGroupVolume([30, 45, 50], 50)).toEqual([38, 53, 58]);
+    });
+
+    test('empty membership yields an empty result', () => {
+      expect(applyGroupVolume([], 50)).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary

Follows up on per-output volume (#23). The previous master behavior was "set all" — moving the master flattened every selected speaker to the same number. As Ben noted, **60 on a stereo pair is very different from 60 on a HomePod mini**, and flattening also wiped out any balance you'd dialed in.

This switches to **Apple's group-volume model**:
- The master *is the average* of the selected speakers (`state.volume`).
- Moving the master shifts every selected speaker by the same delta, **preserving their relative balance** — a speaker you set quieter stays proportionally quieter.
- Changing one speaker (or the selection) re-broadcasts `volume` as the new average, so the master tracks the group live.

### Behavior

| Start (Kitchen, Office) | Action | Result |
| --- | --- | --- |
| 50, 50 | master → 70 | 70, 70 *(equal speakers ⇒ same as set-all)* |
| 30, 50 (avg 40) | master → 60 | 50, 70 *(both +20, 20-pt gap preserved)* |
| 30, 50 | Kitchen → 10 | master redisplays avg 30; Office stays 50 |

When all speakers are equal it's identical to the old set-all, so nothing changes until you actually trim speakers apart. At the 0/100 rails a clamped speaker's offset compresses (the additive model can't preserve an offset past a rail) — documented in API.md.

### Implementation
- `lib/devices.js`: pure `averageVolume` and `applyGroupVolume(values, target)` (clamped, rounded) — fully unit-tested.
- `setVolume` shifts members to the target average; `setOutputVolume` / `setOutput` / autoconnect keep `state.volume` = group average.
- No client changes needed — web UI and AirSpin just adopt the `volume` + `outputVolume` broadcasts. The web UI master slider now visibly drags the per-speaker sliders together, preserving spacing.

## Testing

- `npm test`: **113 pass** (7 new unit tests: balance preservation, set-all equivalence, no-op at current average, rail clamping, rounding, empty membership)
- Not yet exercised against real AirPlay hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
