### PR TITLE
Per-speaker default volumes (balanced autoconnect)

### DIFF
--- a/API.md
+++ b/API.md
@@ -221,12 +221,15 @@ BabelPod stores instance configuration in `babelpod.config.json` alongside the s
 {
   "displayName": "PattyPi",
   "defaultInputId": "plughw:0,0",
-  "defaultOutputIds": ["air:Kitchen"],
+  "defaultOutputIds": ["air:Kitchen", "airpair:Living Room"],
   "defaultVolume": 50,
+  "defaultOutputVolumes": { "air:Kitchen": 65, "airpair:Living Room": 40 },
   "autoconnectEnabled": true,
   "autoconnectThreshold": 0.01
 }
 ```
+
+`defaultOutputVolumes` (v1.1) is a per-speaker default volume map (`{ outputId: 0–100 }`). When autoconnect brings up the default outputs, each speaker comes up at its own level here, falling back to `defaultVolume` for any default speaker without an entry — so the default setup keeps its balance instead of all speakers starting at one number. AirPlay outputs only; the server clamps/rounds values and drops malformed entries on save. Settable via `setConfig` (the web UI Settings shows a slider per default speaker).
 
 ## Autoconnect
 
@@ -284,7 +287,7 @@ Each output can carry its own volume independent of the master. The contract is 
 - **Per-output volume is the authoritative device gain** (an absolute 0–100 level). `setOutputVolume {id, value}` sets one speaker directly.
 - **Master volume follows Apple's group model.** `state.volume` is the *average* of the selected speakers' per-output volumes. `setVolume` shifts every selected speaker by the same delta to reach the requested average, **preserving their relative balance** — so a speaker you set quieter stays proportionally quieter (60 on a stereo pair and 45 on a mini hold their offset when you move the group). When all speakers are equal this is identical to "set all"; balance is only preserved once you've trimmed speakers apart. At the 0/100 rails a clamped speaker's offset compresses (the additive model can't preserve an offset past a rail). Changing one speaker via `setOutputVolume` likewise re-broadcasts `volume` with the new average, and a newly selected speaker joins at the current group level.
 - **Events:** `setOutputVolume {id, value}` (client→server, owner-only, clamped/rounded, unknown ids ignored) → applies the gain and broadcasts `outputVolume {id, value}` to all clients. `setVolume` broadcasts `volume` plus one `outputVolume` per shifted speaker.
-- **Persistence.** Per-output volumes are runtime state, like the master `volume` — they survive reconnects (re-read from `state`) but reset on server restart. (This is deliberate: persisting every slider movement to `babelpod.config.json` would hammer the Pi's SD card. The master volume behaves the same way.)
+- **Persistence.** Live per-output volumes are runtime state, like the master `volume` — they survive reconnects (re-read from `state`) but reset on server restart. (This is deliberate: persisting every slider movement to `babelpod.config.json` would hammer the Pi's SD card.) For a setup that should *start* balanced, configure `defaultOutputVolumes` (see [Instance Configuration](#instance-configuration)) — those per-speaker defaults are saved to config and applied each time autoconnect brings the default speakers up.
 
 ## Turntable Power & Silence Auto-Off (v1.1)
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -35,6 +35,10 @@ The Burr-Brown/TI USB Audio CODEC has no ALSA capture volume control — gain is
 - **HTTP command endpoint (§4):** `POST /api/setVolume|setOutputVolume|setTurntablePower` + `GET /api/state` with a shared-secret token, for AirSpin App Intents / Siri Shortcuts. Privileged (bypasses session owner), routes through the same control core, LAN only.
 - **HomeKit volume accessory (§5):** HAP-NodeJS Lightbulb whose `Brightness` maps to volume (the only Siri-controllable numeric), two-way sync, per-output Lightbulbs once §1 lands.
 
+## iOS App: per-speaker default volumes parity
+
+The server + web UI support `defaultOutputVolumes` (per-speaker default volume map applied on autoconnect; see API.md "Instance Configuration"). AirSpin's "save current as defaults" (`BabelPodClientView.swift`, ~line 968) only saves `defaultOutputIds` + a single `defaultVolume`, so saving defaults from iOS loses the per-speaker balance. For parity, AirSpin should read `config.defaultOutputVolumes`, include it when saving defaults (e.g. from the current per-output volumes of the selected speakers), and ideally expose per-speaker default sliders in its settings. Degrades gracefully today — iOS ignores the field and balanced autoconnect still works regardless of which client armed it.
+
 ## iOS App: Push Notification to Turn Off Record Player
 
 When autoconnect transitions from silence to idle (speakers released after 5 minutes of silence), send a push notification from the iOS app reminding the user to turn off the record player. The record is still spinning in the runout groove — the user may have walked away.

--- a/index.html
+++ b/index.html
@@ -881,8 +881,11 @@
           defaultInputSelect.appendChild(opt);
         });
 
-        // Populate default outputs checkboxes
+        // Populate default outputs checkboxes (with a per-speaker default
+        // volume slider for outputs that support per-output volume)
         const defaultOutputsDiv = document.getElementById("settingsDefaultOutputs");
+        const defaultVolumes = currentConfig.defaultOutputVolumes || {};
+        const fallbackVolume = currentConfig.defaultVolume || 50;
         while (defaultOutputsDiv.firstChild) defaultOutputsDiv.removeChild(defaultOutputsDiv.firstChild);
         availableOutputsList.forEach((output) => {
           const label = document.createElement("label");
@@ -892,6 +895,27 @@
           checkbox.checked = (currentConfig.defaultOutputIds || []).includes(output.id);
           label.appendChild(checkbox);
           label.appendChild(document.createTextNode(output.name));
+
+          // Per-speaker default volume — only for outputs that report a volume
+          if (typeof output.volume === "number") {
+            label.style.flexWrap = "wrap";
+            const slider = document.createElement("input");
+            slider.type = "range";
+            slider.min = "0";
+            slider.max = "100";
+            slider.value = defaultVolumes[output.id] ?? fallbackVolume;
+            slider.className = "settings-default-volume";
+            slider.dataset.outputId = output.id;
+            slider.style.flex = "1 1 100%";
+            slider.style.marginTop = "0.4rem";
+            slider.style.setProperty("--progress", slider.value + "%");
+            slider.addEventListener("click", (e) => e.stopPropagation());
+            slider.addEventListener("pointerdown", (e) => e.stopPropagation());
+            slider.addEventListener("input", (ev) => {
+              ev.target.style.setProperty("--progress", ev.target.value + "%");
+            });
+            label.appendChild(slider);
+          }
           defaultOutputsDiv.appendChild(label);
         });
       }
@@ -912,6 +936,14 @@
         defaultOutputCheckboxes.forEach((cb) => {
           if (cb.checked) selectedDefaultOutputs.push(cb.value);
         });
+
+        // Collect per-speaker default volumes from their sliders
+        const defaultOutputVolumes = {};
+        document.getElementById("settingsDefaultOutputs")
+          .querySelectorAll("input.settings-default-volume")
+          .forEach((slider) => {
+            defaultOutputVolumes[slider.dataset.outputId] = Number(slider.value);
+          });
 
         const inputMode = document.getElementById("settingsInputMode").value;
         // Phono mode: signal amplified by preamp (~0.03+ music), higher threshold
@@ -939,6 +971,7 @@
           defaultInputId: document.getElementById("settingsDefaultInput").value,
           defaultOutputIds: selectedDefaultOutputs,
           defaultVolume: Number(document.getElementById("settingsDefaultVolume").value),
+          defaultOutputVolumes: defaultOutputVolumes,
           autoconnectEnabled: document.getElementById("settingsAutoconnectEnabled").checked,
           autoconnectThreshold: autoconnectThreshold
         });

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const dnssd = require('dnssd2');
 const AirTunes = require('airtunes2');
 const { hostname } = require('os');
 const path = require('path');
-const { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume, outputSupportsVolume, averageVolume, applyGroupVolume } = require('./lib/devices');
+const { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume, outputSupportsVolume, averageVolume, applyGroupVolume, sanitizeDefaultOutputVolumes } = require('./lib/devices');
 const { SilenceAutoOff } = require('./lib/turntable');
 const { MatterPlugController } = require('./lib/plugController');
 
@@ -47,6 +47,10 @@ const DEFAULT_CONFIG = {
   defaultInputId: null,
   defaultOutputIds: [],
   defaultVolume: 50,
+  // Per-default-speaker volumes ({ outputId: 0-100 }). When autoconnect brings
+  // up the default speakers, each comes up at its own level here (falling back
+  // to defaultVolume), so the default setup keeps its balance. AirPlay only.
+  defaultOutputVolumes: {},
   autoconnectEnabled: false,
   autoconnectThreshold: 0.01,
   // Turntable smart plug (Matter). Commission once by putting the plug in
@@ -239,14 +243,19 @@ function activateDefaultOutputs() {
   if (validOutputIds.length > 0) {
     syncOutputs(validOutputIds);
     io.emit('output', { ids: validOutputIds });
-    // Fresh autoconnect brings every speaker up at the default level (overriding
-    // any remembered per-output trims), so the group starts balanced
+    // Fresh autoconnect brings each speaker up at its configured default level
+    // (per-speaker default, falling back to defaultVolume) so the default setup
+    // keeps its balance rather than flattening everyone to one number.
+    const defaultVolumes = config.defaultOutputVolumes || {};
     validOutputIds.forEach(uiId => {
       if (!outputSupportsVolume(uiId)) return;
-      outputVolumes[uiId] = volume;
+      const level = defaultVolumes[uiId] ?? volume;
+      outputVolumes[uiId] = level;
       applyOutputVolume(uiId);
-      io.emit('outputVolume', { id: uiId, value: volume });
+      io.emit('outputVolume', { id: uiId, value: level });
     });
+    // Master reflects the resulting group average (speakers may differ now)
+    volume = computeGroupVolume();
     io.emit('volume', { value: volume });
     const missing = config.defaultOutputIds.length - validOutputIds.length;
     const message = missing > 0
@@ -1264,13 +1273,17 @@ io.on('connection', socket => {
 
     // Only allow known fields
     const allowedFields = [
-      'displayName', 'defaultInputId', 'defaultOutputIds', 'defaultVolume',
+      'displayName', 'defaultInputId', 'defaultOutputIds', 'defaultVolume', 'defaultOutputVolumes',
       'autoconnectEnabled', 'autoconnectThreshold',
       'autoOffEnabled', 'autoOffSilenceThresholdDb', 'autoOffNoiseFloorDb', 'autoOffSilenceMinutes'
     ];
     const filtered = {};
     for (const key of allowedFields) {
       if (key in data) filtered[key] = data[key];
+    }
+    // Sanitize the per-default-speaker volume map (clamp/round, drop malformed)
+    if ('defaultOutputVolumes' in filtered) {
+      filtered.defaultOutputVolumes = sanitizeDefaultOutputVolumes(filtered.defaultOutputVolumes);
     }
 
     saveConfig(filtered);

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -125,6 +125,21 @@ function applyGroupVolume(values, target) {
   return values.map(v => Math.round(clampVolume(v + delta)));
 }
 
+// Sanitize a default per-output volume map ({ outputId: volume }). Keeps only
+// entries with a finite numeric value, clamped to an integer 0-100. Returns a
+// new plain object (drops anything malformed).
+function sanitizeDefaultOutputVolumes(map) {
+  const clean = {};
+  if (map && typeof map === 'object' && !Array.isArray(map)) {
+    for (const [id, value] of Object.entries(map)) {
+      if (typeof id === 'string' && typeof value === 'number' && Number.isFinite(value)) {
+        clean[id] = Math.round(clampVolume(value));
+      }
+    }
+  }
+  return clean;
+}
+
 module.exports = {
   parsePcmDevices,
   parseAirplayService,
@@ -132,5 +147,6 @@ module.exports = {
   clampVolume,
   outputSupportsVolume,
   averageVolume,
-  applyGroupVolume
+  applyGroupVolume,
+  sanitizeDefaultOutputVolumes
 };

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -309,6 +309,18 @@ describe('Socket.IO API Contract', () => {
       const config = await configPromise;
       expect(config.defaultVolume).toBe(60);
     });
+
+    test('setConfig persists and sanitizes per-speaker default volumes', async () => {
+      client = await connectClient();
+      await waitForEvent(client, 'state');
+
+      const configPromise = waitForEvent(client, 'config');
+      client.emit('setConfig', {
+        defaultOutputVolumes: { 'air:Kitchen': 150, 'air:Office': 40.4, 'air:Bad': 'loud' }
+      });
+      const config = await configPromise;
+      expect(config.defaultOutputVolumes).toEqual({ 'air:Kitchen': 100, 'air:Office': 40 });
+    });
   });
 
   describe('Autoconnect', () => {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -107,3 +107,25 @@ describe('Web UI — per-output volume', () => {
     expect(document.querySelectorAll('#outputsList input.output-volume').length).toBe(0);
   });
 });
+
+describe('Web UI — per-speaker default volumes (settings)', () => {
+  test('settings shows a default-volume slider per capable output, seeded from config', () => {
+    loadUi();
+    fire('state', {
+      ...baseState,
+      config: { defaultVolume: 55, defaultOutputVolumes: { 'air:Kitchen': 30 } },
+      outputs: [
+        { id: 'air:Kitchen', name: 'Kitchen - AirPlay', volume: 50 },
+        { id: 'air:Office', name: 'Office - AirPlay', volume: 50 }, // no explicit default → fallback
+        { id: 'plughw:0,0', name: 'Headphones - Output' },          // no volume → no slider
+      ],
+    });
+
+    const sliders = document.querySelectorAll('#settingsDefaultOutputs input.settings-default-volume');
+    expect(sliders.length).toBe(2);
+    const byId = {};
+    sliders.forEach((s) => { byId[s.dataset.outputId] = s.value; });
+    expect(byId['air:Kitchen']).toBe('30');  // from config.defaultOutputVolumes
+    expect(byId['air:Office']).toBe('55');    // falls back to defaultVolume
+  });
+});

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -3,7 +3,7 @@
  * These tests don't require hardware and test pure logic functions
  */
 
-const { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume, outputSupportsVolume, averageVolume, applyGroupVolume } = require('../lib/devices');
+const { parsePcmDevices, parseAirplayService, buildUnifiedOutputs, clampVolume, outputSupportsVolume, averageVolume, applyGroupVolume, sanitizeDefaultOutputVolumes } = require('../lib/devices');
 
 describe('BabelPod Utility Functions', () => {
   describe('parsePcmDevices', () => {
@@ -137,6 +137,25 @@ describe('BabelPod Utility Functions', () => {
 
     test('empty membership yields an empty result', () => {
       expect(applyGroupVolume([], 50)).toEqual([]);
+    });
+  });
+
+  describe('sanitizeDefaultOutputVolumes', () => {
+    test('clamps and rounds numeric values', () => {
+      expect(sanitizeDefaultOutputVolumes({ 'air:Kitchen': 150, 'airpair:LR': -5, 'air:X': 40.6 }))
+        .toEqual({ 'air:Kitchen': 100, 'airpair:LR': 0, 'air:X': 41 });
+    });
+
+    test('drops non-numeric and non-finite values', () => {
+      expect(sanitizeDefaultOutputVolumes({ 'air:K': 'loud', 'air:Z': NaN, 'air:Y': 30 }))
+        .toEqual({ 'air:Y': 30 });
+    });
+
+    test('returns an empty object for non-object input', () => {
+      expect(sanitizeDefaultOutputVolumes(null)).toEqual({});
+      expect(sanitizeDefaultOutputVolumes(undefined)).toEqual({});
+      expect(sanitizeDefaultOutputVolumes([1, 2])).toEqual({});
+      expect(sanitizeDefaultOutputVolumes('x')).toEqual({});
     });
   });
 


### PR DESCRIPTION
## Summary

**Answer to "can volumes be set on default speakers?": previously no** — the default speakers all came up at the single `defaultVolume` on autoconnect (my #24 change even made that explicit), so any per-speaker balance was flattened. This adds it.

New config field **`defaultOutputVolumes`** — a per-speaker default volume map (`{ outputId: 0–100 }`). When autoconnect brings up the default outputs, each speaker comes up at its own configured level, falling back to `defaultVolume` for any default speaker without an entry. So your default setup keeps its balance (e.g. Living Room pair at 40, Kitchen at 65) instead of everyone starting at one number.

### Why this one *is* persisted to disk
Unlike live per-output volumes (#23), which are runtime-only to spare the Pi's SD card from every slider drag, these are **configuration** — set deliberately and infrequently in Settings — so they belong in `babelpod.config.json` and survive restarts.

### Changes
- `DEFAULT_CONFIG.defaultOutputVolumes` + `setConfig` accepts it, sanitized via `sanitizeDefaultOutputVolumes` (clamp to 0–100, round, drop malformed entries).
- `activateDefaultOutputs` applies each speaker's configured default and sets the master to the resulting group average (consistent with the #24 group model).
- Web UI Settings: a default-volume slider per capable default speaker, seeded from config (falling back to `defaultVolume`), collected on save.
- API.md documents the field.

### iOS parity
AirSpin already edits config (its "save current as defaults"), but only saves `defaultOutputIds` + a single `defaultVolume` — so saving defaults from iOS doesn't yet capture per-speaker levels. It **degrades gracefully** (ignores the new field; balanced autoconnect works no matter which client armed it). Tracked as a follow-up in BACKLOG.md.

## Testing

- `npm test`: **118 pass** (unit: sanitizer clamp/round/drop; api: `setConfig` sanitize + round-trip via the `config` event; ui/jsdom: settings renders a default-volume slider per capable speaker, seeded from `defaultOutputVolumes` with `defaultVolume` fallback)
- `node -c index.js` + embedded UI JS syntax-checked
- Not yet exercised against real AirPlay hardware (autoconnect path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
