### PR TITLE
Show BabelPod's name in AirPlay receiver prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ BabelPod is an audio streaming system with two repositories:
 - **This repo** (`benlachman/babelpod`) — Node.js server + web UI. The server (`index.js`) captures audio from a selected input and streams it to multiple outputs. The web UI (`index.html`) is served by Express. Both are plain JavaScript, no build step.
 - **iOS/macOS app** (`nicemohawk/airspin`) at `/Users/ben/Development/BabelUI` — SwiftUI client that connects to the same server. Separate repo, separate release cycle, but must maintain API parity.
 
-The server runs on a **Raspberry Pi Zero 2 W** (ARM64, 512MB RAM, Debian/Trixie). Audio capture and playback use ALSA tools (`arecord`, `aplay`) via spawned child processes. AirPlay streaming uses `node_airtunes2`. Bluetooth input uses `bluetoothctl` via a Node wrapper. Device discovery uses `dnssd2` (mDNS) and `mdns-js`.
+The server runs on a **Raspberry Pi Zero 2 W** (ARM64, 512MB RAM, Debian/Trixie). Audio capture and playback use ALSA tools (`arecord`, `aplay`) via spawned child processes. AirPlay streaming uses `node_airtunes2` — pinned to our fork (`benlachman/node_airtunes2#babelpod-sender-name`, branched from `ciderapp`'s `v2.4.9`) which adds a `name` option to `add()` so the AirPlay receiver prompt shows the server's display name; BabelPod passes `config.displayName`. Bluetooth input uses `bluetoothctl` via a Node wrapper. Device discovery uses `dnssd2` (mDNS) and `mdns-js`.
 
 ## Commands
 

--- a/index.js
+++ b/index.js
@@ -1113,7 +1113,8 @@ function syncOutputs(newSelected) {
                 airtunes.add(device.host, {
                   port: device.port,
                   volume: outputVolume,
-                  stereo: !!device.isStereo
+                  stereo: !!device.isStereo,
+                  name: config.displayName // shown in AirPlay receiver prompts (e.g. macOS)
                 });
                 // Track active AirPlay devices
                 if (!activeAirPlayDevices.includes(deviceKey)) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@matter/main": "^0.17.2",
     "@project-chip/matter.js": "^0.17.2",
-    "airtunes2": "ciderapp/node_airtunes2#v2.4.9",
+    "airtunes2": "benlachman/node_airtunes2#babelpod-sender-name",
     "bluetoothctl": "https://github.com/DerDaku/node-bluetoothctl.git",
     "dnssd2": "^1.0.0",
     "express": "^4.17.1",


### PR DESCRIPTION
## Summary

AirPlay receivers (e.g. macOS's "_X_ would like to AirPlay to this Mac" prompt) showed an empty `""` because `node_airtunes2` never sends a sender name and exposes no option for one. Confirmed against the AirPlay 2 protocol docs that the prompt label is the **`name`** key in the SETUP request's plist.

Since the name lives inside the dependency, this pins `node_airtunes2` to **our fork** ([benlachman/node_airtunes2 @ babelpod-sender-name](https://github.com/benlachman/node_airtunes2/tree/babelpod-sender-name), branched from `ciderapp`'s `v2.4.9`), which adds a `name` option to `add()`:
- sent as the AirPlay 2 SETUP plist **`name`** (the confirmed field), and
- as an **`X-Apple-Client-Name`** header on the RAOP path (belt-and-suspenders, since BabelPod connects in RAOP mode by default).
- defaults to `""` when omitted — no behavior change for other receivers.

BabelPod passes `config.displayName` in `airtunes.add(...)`.

## ⚠️ Deploy note
This changes the `airtunes2` dependency, so the Pi needs **`npm install`** after pulling — deploy is `git pull && npm install && sudo systemctl restart babelpod`, not just pull+restart.

## Testing

- `npm test`: 124 pass; `node -c index.js` clean.
- Verified the `name` option threads into the RTSP client (`new RTSP.Client(..., {name})` → `client.name`), and defaults to `""` when omitted.
- **Needs one live check on real hardware**: stream to a Mac (AirPlay receiver) and confirm the prompt now reads the server's display name instead of `""`. If the RAOP path ignores the header, the fallback is to confirm whether the AP2 plist path is exercised — will verify on the Pi against Skippy Nano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)