### PR TITLE
Dedupe duplicate AirPlay outputs (unique ids in state.outputs)

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -88,7 +88,17 @@ function buildUnifiedOutputs(availablePcmOutputs, availableAirplayOutputs) {
       });
     }
   }
-  return local.concat(air);
+
+  // Guarantee unique uiIds. The same device can be discovered on multiple
+  // interfaces/addresses (same name, different host); since a single device's
+  // uiId is name-only (`air:<name>`), those would otherwise collapse to two
+  // entries with an identical id. Clients key on id, so keep the first.
+  const seenUiIds = new Set();
+  return local.concat(air).filter(output => {
+    if (seenUiIds.has(output.uiId)) return false;
+    seenUiIds.add(output.uiId);
+    return true;
+  });
 }
 
 // Clamp a volume value to the 0-100 range.

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -54,6 +54,33 @@ describe('BabelPod Utility Functions', () => {
       expect(unified).toHaveLength(1);
     });
 
+    test('should collapse the same device discovered on multiple addresses to one unique id', () => {
+      // Same name, different host (e.g. a Mac advertising AirPlay on two
+      // interfaces) — both map to the name-only uiId `air:Skippy Nano`.
+      const airplay = [
+        { name: 'Skippy Nano', stereo: null, host: '192.168.4.76', port: 7000 },
+        { name: 'Skippy Nano', stereo: null, host: '192.168.5.119', port: 7000 }
+      ];
+      const unified = buildUnifiedOutputs([], airplay);
+      const ids = unified.map(o => o.uiId);
+      expect(ids).toEqual(['air:Skippy Nano']); // exactly once
+      expect(new Set(ids).size).toBe(ids.length); // all ids unique
+    });
+
+    test('emitted ids are always unique across a mixed device list', () => {
+      const airplay = [
+        { name: 'Skippy Nano', stereo: null, host: '10.0.0.1', port: 7000 },
+        { name: 'Skippy Nano', stereo: null, host: '10.0.0.2', port: 7000 },
+        { name: 'Kitchen', stereo: null, host: '10.0.0.3', port: 7000 },
+        { name: 'L', stereo: 'Living Room', host: '10.0.0.4', port: 7000 },
+        { name: 'R', stereo: 'Living Room', host: '10.0.0.5', port: 7000 }
+      ];
+      const pcm = [{ id: 'plughw:0,0', name: 'USB', output: true, input: false }];
+      const ids = buildUnifiedOutputs(pcm, airplay).map(o => o.uiId);
+      expect(new Set(ids).size).toBe(ids.length);
+      expect(ids.filter(id => id === 'air:Skippy Nano')).toHaveLength(1);
+    });
+
     test('should group stereo pairs sharing a group name', () => {
       const airplay = [
         { name: 'Left HomePod', stereo: 'Living Room', host: '192.168.1.20', port: 7000 },


### PR DESCRIPTION
## Summary

`state.outputs` (and the `outputs` event) could contain the same AirPlay device twice with a **non-unique `id`** — e.g. two identical `{"id":"air:Skippy Nano",...}` entries — breaking clients that key on id (iOS per-output selection/volume, SwiftUI lists).

**Root cause:** in `buildUnifiedOutputs`, the dedup keys on `name + host + port`, but a single device's `uiId` is **name-only** (`air:<name>`). When the same device is discovered on more than one interface/address (same name, different host — confirmed live: Skippy Nano on both `192.168.4.76` and `192.168.5.119`), the two entries survive dedup and then collapse to the *same* `air:<name>` id.

**Fix:** after assembling the unified list, filter to **unique `uiId`s** (keep first). The id scheme (`air:<name>`) and `{id, name, volume?}` shape are unchanged. Both source addresses are still tracked in `availableAirplayOutputs`, so if one interface drops, `serviceDown` removes just that address and the device stays — we just present one entry.

I deliberately fixed it at the **assembly point rather than the discovery source**: keeping both addresses is useful for failover, and assembly-point dedup is a robust guard against *any* source-level duplication that yields the same id.

## Testing

- `npm test`: **126 pass** (+2: same-device-on-two-addresses collapses to one `air:Skippy Nano`; ids unique across a mixed local + duplicate + stereo-pair list).
- Live server currently shows 14 outputs / 13 unique (`air:Skippy Nano` repeated) — will re-verify == after deploy.

## Acceptance

`state.outputs` / `outputs` never contain repeated ids; Skippy Nano appears exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)